### PR TITLE
Use restrict ip address

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'plain-david', github: 'k1w1/plain-david' # HTML to plain text conversion.
 gem 'sinatra'
 gem 'crack'
 gem 'restforce'
+gem 'faraday-restrict-ip-addresses', '~> 0.1.0'
 
 # Auto reload sinatra
 gem 'rerun'

--- a/aha-services.gemspec
+++ b/aha-services.gemspec
@@ -39,6 +39,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "aha-api"
 
+  s.add_dependency "faraday-restrict-ip-addresses", '~> 0.1.0'
+
   s.files        = Dir.glob("{lib}/**/*") + %w(LICENSE README.md)
   s.require_path = 'lib'
 end

--- a/lib/aha-services/networking.rb
+++ b/lib/aha-services/networking.rb
@@ -28,6 +28,8 @@ module Networking
 
   # Override this to install additional middleware.
   def faraday_builder(builder)
+    builder.request :restrict_ip_addresses, deny_rfc6890: true,
+                                            allow_localhost: false
   end
 
   # Reset the HTTP connection so it can be recreated with new options.

--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.17.17"
+  VERSION = "1.17.18"
 end


### PR DESCRIPTION
This is to ensure we do not ping our internal network in integrations. 

Is blocked until the gem author pushes a new version to ruby gems, I have submitted an issue on the repo to get this done.