### PR TITLE
Call createmeta separately for each project.

### DIFF
--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.18.8"
+  VERSION = "1.18.9"
 end


### PR DESCRIPTION
Prevents timeouts when working with slow servers, or servers with many projects.