### PR TITLE
Don't create cards with due dates when release is in parking lot.

### DIFF
--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.20.78"
+  VERSION = "1.20.79"
 end

--- a/lib/services/trello.rb
+++ b/lib/services/trello.rb
@@ -76,7 +76,9 @@ class AhaServices::Trello < AhaService
   end
 
   def create_card_for(feature)
-    due_date = feature.due_date || feature.release.release_date
+    due_date = unless feature.release.parking_lot
+      feature.due_date || feature.release.release_date
+    end
     
     card = card_resource.create(
       name: resource_name(feature),


### PR DESCRIPTION
The `feature/release/parking_lot` field isn't yet emitted by the API in this context, but it will be shortly. In the meantime, `Hashie::Mash` ensures it will behave as it used to by returning `nil`.