### PR TITLE
Add labels syncing with github issues

### DIFF
--- a/docs/github_issues.md
+++ b/docs/github_issues.md
@@ -9,12 +9,13 @@ This two-way integration allows you to push your features and requirements in Ah
 * There are two ways to map requirements to issues. Each requirement can be mapped to a stand-alone issue, or the requirements can be converted to a checklist within the main issue. If checklists are used, note that there are some significant caveats:
   * When checklist items are ticked, the status of the corresponding requirement in Aha! will not be updated.
   * Each time the feature is updated in Github using the _Update Github_ menu item, the entire issue description will be overwritten, reseting the status of any checklist items that are already complete.
-* Only the description of a feature or requirement is sent. No tasks or comments are included. 
+* Only the description of a feature or requirement is sent. No tasks or comments are included.
 * Attachments of a feature or requirement are also sent.
 * Tags on a feature in Aha! will becomes labels in Github.
 * Aha! releases will be created as milestones in Github.
-* After a feature is first sent to Github, changes to the name, description and requirements, can also be sent to Github using the _Update Github_ item in the _Actions_ menu on the features page or by sending all features in a release to Github again. New requirements will also be created in Github, however issues that were created for an existing requirement are not deleted from Github if the requirement is deleted from Aha!. If an attachment is deleted in Aha! the corresponding attachment in Github is not deleted. 
-
+* After a feature is first sent to Github, changes to the name, description and requirements, can also be sent to Github using the _Update Github_ item in the _Actions_ menu on the features page or by sending all features in a release to Github again. New requirements will also be created in Github, however issues that were created for an existing requirement are not deleted from Github if the requirement is deleted from Aha!. If an attachment is deleted in Aha! the corresponding attachment in Github is not deleted.
+* When "Add status labels" is enabled and the feature is updated using _Send to Github Issues_ the state of the feature will be added as a label in Github with the prefix "aha:" ie. "aha:In development".
+* With "Add status labels" enabled the state of corresponding feature to the Github Issues can be changed to the desired aha state by adding a Github label with with the "aha:" prefix and removing the label representing the features previous state. ie. remove the label "aha:In development" and add "aha:Ready to ship". Note: only one label with the prefix "aha:" will be allowed on a Github issue
 
 ## Configuration
 
@@ -27,7 +28,7 @@ Create the integration in Aha!
 1. Enter your Github username and password. Consider using a [Github Personal Token](https://help.github.com/articles/creating-an-access-token-for-command-line-use) rather than a password here. A token is essential if you use two-factor authentication with your Github account. Click the _Test connection_ button
 2. After a short delay, you will be able to choose the repository the issues will be created in.
 3. Enable the integration.
-4. Test the integration by going to one of your features in Aha! and using the _Send to Github Issues_ item in the _Actions_ menu on the features page. You should then look at your repository in Github and see that the feature (and any requirements) were properly copied to issues. 
+4. Test the integration by going to one of your features in Aha! and using the _Send to Github Issues_ item in the _Actions_ menu on the features page. You should then look at your repository in Github and see that the feature (and any requirements) were properly copied to issues.
 
 To receive updates when an issue is changed on Github you have to setup a webhook for the Github repository.
 

--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.22.0"
+  VERSION = "1.23.0"
 end

--- a/spec/services/github_issues_spec.rb
+++ b/spec/services/github_issues_spec.rb
@@ -15,7 +15,7 @@ describe AhaServices::GithubIssues do
                                   workflow_status: {name: 'In development'},
                                   description: { body: 'First feature description' },
                                   release: release,
-                                  tags: [ 'First', 'Second', 'Third', 'aha:First' ],
+                                  tags: [ 'First', 'Second', 'Third', 'Aha!:First' ],
                                   requirements: [ { id: 'req_id' } ] }
 
   let(:repo_resource) { double }
@@ -406,11 +406,11 @@ describe AhaServices::GithubIssues do
     end
     context "add_status_labeled is enabled" do
       before do
-        service.stub(:data).and_return(Hashie::Mash.new({add_status_labels: 1}))
+        service.stub(:data).and_return(Hashie::Mash.new({add_status_labels: "1"}))
       end
       it "returns the updated labels" do
         label_resource.should_receive(:update)
-          .with(mock_issue["number"], ['First', 'Second', 'Third', 'aha:In development'])
+          .with(mock_issue["number"], ['First', 'Second', 'Third', 'Aha!:In development'])
           .and_return(mock_labels)
         service.update_labels(mock_issue, feature)
       end
@@ -483,7 +483,7 @@ describe AhaServices::GithubIssues do
   end
   #
   describe "#receive_webhook" do
-    let(:mock_issue) { { number: 42, title: "The issue", labels: [{name:"First"}, {name:"Second"}, {name: "Third"}, {name: "aha:Shipped"}] } }
+    let(:mock_issue) { { number: 42, title: "The issue", labels: [{name:"First"}, {name:"Second"}, {name: "Third"}, {name: "Aha!:Shipped"}] } }
     let(:mock_api_client) { double }
     after do
       service.stub(:api).and_return(mock_api_client)
@@ -518,7 +518,7 @@ describe AhaServices::GithubIssues do
 
       context "with add_status_labels enabled" do
         before do
-          service.stub(:data).and_return(Hashie::Mash.new({add_status_labels: true, integration_id: 1000, status_mapping: {open: '12345', closed: '67890'}}))
+          service.stub(:data).and_return(Hashie::Mash.new({add_status_labels: "1", integration_id: 1000, status_mapping: {open: '12345', closed: '67890'}}))
         end
 
         context "and labeled action" do
@@ -528,22 +528,22 @@ describe AhaServices::GithubIssues do
             mock_api_client.should_receive(:put).with('some-resource', {feature: expected_diff})
           end
           it "should update the issue to only have one aha-label if more then one aha-label is added" do
-            mock_issue[:labels].push({name: 'aha:In Development'})
+            mock_issue[:labels].push({name: 'Aha!:In Development'})
             service.stub(:payload).and_return(Hashie::Mash.new({webhook: { action: 'labeled', issue: mock_issue }}))
-            label_resource.should_receive(:update).with(mock_issue[:number], ["First", "Second", "Third", "aha:In Development"])
+            label_resource.should_receive(:update).with(mock_issue[:number], ["First", "Second", "Third", "Aha!:In Development"])
             mock_api_client.stub(:put)
           end
         end
         context "and unlabeled action" do
-          it "should add the label back to the issue when there is no aha labels" do
-            mock_issue[:labels].pop # remove the aha:In Development label
-            service.stub(:payload).and_return(Hashie::Mash.new({label: {name: 'aha:Shipped'}, webhook: { action: 'unlabeled', issue: mock_issue }}))
-            label_resource.should_receive(:update).with(mock_issue[:number], ["First", "Second", "Third", "aha:Shipped"])
+          it "should add the label back to the issue when there is no Aha! labels" do
+            mock_issue[:labels].pop # remove the Aha!:In Development label
+            service.stub(:payload).and_return(Hashie::Mash.new({label: {name: 'Aha!:Shipped'}, webhook: { action: 'unlabeled', issue: mock_issue }}))
+            label_resource.should_receive(:update).with(mock_issue[:number], ["First", "Second", "Third", "Aha!:Shipped"])
             service.stub(:label_resource).and_return(label_resource)
             mock_api_client.stub(:put)
           end
           it "should add the label back to the issue" do
-            service.stub(:payload).and_return(Hashie::Mash.new({label: {name: 'aha:Shipped'}, webhook: { action: 'unlabeled', issue: mock_issue }}))
+            service.stub(:payload).and_return(Hashie::Mash.new({label: {name: 'Aha!:Shipped'}, webhook: { action: 'unlabeled', issue: mock_issue }}))
             label_resource.should_not_receive(:update)
             service.stub(:label_resource).and_return(label_resource)
             mock_api_client.stub(:put)
@@ -552,7 +552,7 @@ describe AhaServices::GithubIssues do
       end
       context "with add_status_labels disabled" do
         before do
-          service.stub(:data).and_return(Hashie::Mash.new({add_status_labels: false, integration_id: 1000, status_mapping: {open: '12345', closed: '67890'}}))
+          service.stub(:data).and_return(Hashie::Mash.new({add_status_labels: "0", integration_id: 1000, status_mapping: {open: '12345', closed: '67890'}}))
         end
 
         context "and labeled action" do
@@ -560,7 +560,7 @@ describe AhaServices::GithubIssues do
             service.stub(:payload).and_return(Hashie::Mash.new({webhook: { action: 'labeled', issue: mock_issue }}))
           end
           it "does not change the workflow status" do
-            expected_diff = {:name=> "The issue", :tags=>["First", "Second", "Third", "aha:Shipped"]}
+            expected_diff = {:name=> "The issue", :tags=>["First", "Second", "Third", "Aha!:Shipped"]}
             mock_api_client.should_receive(:put).with('some-resource', {feature: expected_diff})
           end
         end


### PR DESCRIPTION
Resolves [APP-I-1485](https://big.ideas.aha.io/ideas/APP-I-1485)

Modifies the existing `github_issues` integration to add support for syncing the aha state to a github label. This feature can be enabled or disabled based on the added checkbox to the configuration called "Add status labels" (As shown in screenshot of the form below)

<img width="971" alt="screen shot 2016-08-10 at 12 34 35 pm" src="https://cloud.githubusercontent.com/assets/342085/17562034/db40c554-5ef6-11e6-952c-682c9b11f319.png">

When the feature has been sent to github issues then a label is added to the issue with a prefix/namespace of "aha:". This namespace allows for the plugin to distinguish between status/state changes and regular tags. Only one github label with the prefix "aha:" is allowed when the feature is enabled.

<img width="300" alt="screen shot 2016-08-10 at 12 41 41 pm" src="https://cloud.githubusercontent.com/assets/342085/17562223/de1c9e14-5ef7-11e6-88e2-445fbe3cb713.png">

Changing the label in the corresponding github issue also causes the state of the feature in aha to be updated as well.

14 new tests have been added to test the integration of this new feature.

**Can you please let me know when this feature will be added to production or any changes/ information that I need to provide for this pull request to be accepted as I would like to have this feature integrated ASAP.**
