### PR TITLE
APP-3061: Don't append the requirement description in PT if it already is present

### DIFF
--- a/lib/services/pivotal_tracker/pivotal_tracker_project_dependent_resource.rb
+++ b/lib/services/pivotal_tracker/pivotal_tracker_project_dependent_resource.rb
@@ -9,8 +9,10 @@ class PivotalTrackerProjectDependentResource < PivotalTrackerResource
 protected
 
   def append_link(body, parent_id)
-    if parent_id and @service.data.mapping == "story-story"
-      "#{body}\n\nRequirement of ##{parent_id}."
+    requirement_link = "Requirement of ##{parent_id}"
+
+    if !body.include?(requirement_link) and parent_id and @service.data.mapping == "story-story"
+      "#{body}\n\n#{requirement_link}."
     else
       body
     end

--- a/spec/services/pivotal_tracker/pivotal_tracker_project_dependent_resource_spec.rb
+++ b/spec/services/pivotal_tracker/pivotal_tracker_project_dependent_resource_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe PivotalTrackerProjectDependentResource do
+  let(:service) { double(data: double(mapping: "story-story", logger: double, api_client: double)) }
+  let(:resource) { described_class.new(service, 1234) }
+
+  describe "#create_from_requirement" do
+    it "appends the requirement description when not present" do
+      expect(resource.send(:append_link, "foo", 5678)).to eql("foo\n\nRequirement of #5678.")
+    end
+
+    it "does not append the requirement description when it's already there" do
+      initial_body = "Some existing text.\n\nRequirement of #5678"
+      processed_body = resource.send(:append_link, initial_body, 5678)
+
+      expect(initial_body).to eql(processed_body)
+    end
+  end
+end


### PR DESCRIPTION
Not a big fan of this type of unit test (reaching out to protected method), but there's
not another easy way to get at it.