### PR TITLE
APP-3177: Sync status label back to GitHub when Aha! status is updated via open…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GIT
 PATH
   remote: .
   specs:
-    aha-services (1.23.17)
+    aha-services (1.23.24)
       activesupport
       aha-api
       crack
@@ -72,7 +72,7 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    domain_name (0.5.20160826)
+    domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
@@ -183,4 +183,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.5
+   1.13.6

--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.23.23"
+  VERSION = "1.23.24"
 end

--- a/lib/services/github_issues.rb
+++ b/lib/services/github_issues.rb
@@ -109,6 +109,7 @@ class AhaServices::GithubIssues < AhaService
       end
     when "closed", "opened", "reopened"
       new_status = data.status_mapping.nil? ? nil : data.status_mapping[issue.state]
+      label_resource.update(issue.number, [new_tags, "Aha!:#{new_status}"].flatten) if add_status_labels_enabled? && new_status.present?
       diff[:workflow_status] = new_status if !new_status.nil? && new_status != resource.workflow_status.id
     end
     diff[:tags] = new_tags if Set.new(resource.tags) != Set.new(new_tags)


### PR DESCRIPTION
…ing or closing the issue