### PR TITLE
App 3186 update rally user story with children

### DIFF
--- a/lib/services/rally/rally_hierarchical_requirement_resource.rb
+++ b/lib/services/rally/rally_hierarchical_requirement_resource.rb
@@ -46,7 +46,7 @@ class RallyHierarchicalRequirementResource < RallyResource
     url = rally_secure_url_without_workspace(create_path(element_name))
     payload_key = element_name
     if element_name == "UserStory"
-      payload_key = "HierarchicalRequierement"
+      payload_key = "HierarchicalRequirement"
     end
 
     body[payload_key] = hrequirement
@@ -64,7 +64,8 @@ class RallyHierarchicalRequirementResource < RallyResource
     url = rally_secure_url_without_workspace(object_path(id, element_name)+query_params)
     payload_key = element_name
     if element_name == "UserStory"
-      payload_key = "HierarchicalRequierement"
+      hrequirement.delete(:Release) if has_children?(id, element_name)
+      payload_key = "HierarchicalRequirement"
     end
     body[payload_key] = hrequirement
     response = http_post url, body.to_json
@@ -75,6 +76,12 @@ class RallyHierarchicalRequirementResource < RallyResource
     end
   rescue AhaService::RemoteError => e
     logger.error("Failed to update user story #{id}: #{e.message}")
+  end
+
+  def has_children?(id, element_name)
+    resp = http_get rally_url_without_workspace(object_path(id, element_name)+"/children")
+    children = Hashie::Mash.new(JSON.parse(resp.body))
+    children&.QueryResult&.TotalResultCount.to_i > 0
   end
 
   def human_url_for_feature(id)

--- a/lib/services/rally/rally_hierarchical_requirement_resource.rb
+++ b/lib/services/rally/rally_hierarchical_requirement_resource.rb
@@ -64,7 +64,6 @@ class RallyHierarchicalRequirementResource < RallyResource
     url = rally_secure_url_without_workspace(object_path(id, element_name)+query_params)
     payload_key = element_name
     if element_name == "UserStory"
-      hrequirement.delete(:Release) if has_children?(id, element_name)
       payload_key = "HierarchicalRequirement"
     end
     body[payload_key] = hrequirement
@@ -76,12 +75,6 @@ class RallyHierarchicalRequirementResource < RallyResource
     end
   rescue AhaService::RemoteError => e
     logger.error("Failed to update user story #{id}: #{e.message}")
-  end
-
-  def has_children?(id, element_name)
-    resp = http_get rally_url_without_workspace(object_path(id, element_name)+"/children")
-    children = Hashie::Mash.new(JSON.parse(resp.body))
-    children&.QueryResult&.TotalResultCount.to_i > 0
   end
 
   def human_url_for_feature(id)
@@ -317,7 +310,7 @@ class RallyHierarchicalRequirementResource < RallyResource
       # Rally does not allow you to set the release for a User Story that has other user stories within it
     end
 
-    children_count = get_children(map_to_objectid(aha_model)).length rescue 0
+    children_count = get_children(map_to_objectid(aha_model), @service.feature_element_name).length rescue 0
     return if children_count > 0 # do not send if rally has children for this resource
 
     release_exists = release_id && rally_release_resource.by_id(release_id) rescue false


### PR DESCRIPTION
Rally will throw an error and reject updates if a release id is passed along to an update of a non-leaf-node user story