### PR TITLE
Slack Descriptions should be full-width attachment fields.

### DIFF
--- a/lib/services/slack.rb
+++ b/lib/services/slack.rb
@@ -48,7 +48,7 @@ class AhaServices::Slack < AhaService
 protected
 
   def is_wide_field(field_name)
-    !["Descripition", "Theme", "Body"].include?(field_name)
+    !["Description", "Theme", "Body"].include?(field_name)
   end
 
   def send_message(message)


### PR DESCRIPTION
Fix a word.