### PR TITLE
APP-3507: Gracefully handle unexpected bitbucket payloads

### DIFF
--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.4"
+  VERSION = "1.24.5"
 end

--- a/lib/services/bitbucket_commit_hook.rb
+++ b/lib/services/bitbucket_commit_hook.rb
@@ -16,7 +16,7 @@ class AhaServices::BitbucketCommitHook < AhaService
                      else
                        raise "Unknown type: #{raw_payload.class.inspect} for payload.payload"
                      end
-    commits = (commit_payload.push.changes.flat_map(&:commits) rescue []) || []
+    commits = Array(commit_payload&.push&.changes&.flat_map(&:commits)).compact
     commits.each do |commit|
       commit.message.scan(/([A-Z]+-[0-9]+(?:-[0-9]+)?)/) do |m|
         m.each do |ref|


### PR DESCRIPTION
https://big.aha.io/features/APP-3507
https://sentry.io/aha-labs-inc/aha-production/issues/220276760/

We're getting some payloads where the "commit" element for "commits" are nil.
This makes it so we're a little more explicit with the coercion and more forgiving
in what's handled without error.

Specifically we were get `message undefined` errors on the `commit.message` call within
the commits loop below this change:

```ruby
  commits = (commit_payload.push.changes.flat_map(&:commits) rescue []) || []
  commits.each do |commit|
->  commit.message.scan(/([A-Z]+-[0-9]+(?:-[0-9]+)?)/) do |m|
      m.each do |ref|
        comment_on_record(ref, commit)
      end
```