### PR TITLE
APP-3561: Use `resource_kind` when sending status labels back to GitHub/Lab.

### DIFF
--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.6"
+  VERSION = "1.24.7"
 end

--- a/lib/services/github_issues.rb
+++ b/lib/services/github_issues.rb
@@ -116,7 +116,7 @@ class AhaServices::GithubIssues < AhaService
     if diff.size > 0  then
       updated_resource = api.put(resource.resource, { resource_kind => diff })
       if add_status_labels_enabled? && %w(closed opened reopened).include?(action) && diff.key?(:workflow_status)
-        label_resource.update(issue.number, [new_tags, "Aha!:#{updated_resource.feature.workflow_status.name}"].flatten) 
+        label_resource.update(issue.number, [new_tags, "Aha!:#{updated_resource[resource_kind].workflow_status.name}"].flatten) 
       end
     end
   end

--- a/lib/services/gitlab_issues.rb
+++ b/lib/services/gitlab_issues.rb
@@ -121,7 +121,7 @@ class AhaServices::GitlabIssues < AhaService
     if diff.size > 0  then
       updated_resource = api.put(resource.resource, { resource_kind => diff })
       if add_status_labels_enabled? && %w(close open reopen).include?(action) && diff.key?(:workflow_status)
-        issue_resource.update(issue.id, labels: [new_tags, "Aha!:#{updated_resource.feature.workflow_status.name}"].flatten)
+        issue_resource.update(issue.id, labels: [new_tags, "Aha!:#{updated_resource[resource_kind].workflow_status.name}"].flatten)
       end
     end
   end


### PR DESCRIPTION
Previously we were using the `feature` attribute, but it could be a `requirement` if requirement <-> issue mapping is enabled.