### PR TITLE
normalizing filenames for trello

### DIFF
--- a/lib/services/trello.rb
+++ b/lib/services/trello.rb
@@ -155,8 +155,17 @@ class AhaServices::Trello < AhaService
   def attachments_match(aha_attachment, trello_attachment)
     uri = URI.parse(trello_attachment.url)
     trello_filename = File.basename(uri.path)
-    aha_attachment.file_name == trello_filename and
-      aha_attachment.file_size.to_i == trello_attachment.bytes.to_i
+    # Trello has modified its attachment naming normalization, but it is not
+    # clear whether they updated all previous attachments, so we are checking
+    # against the normalized value and the raw value for backwards
+    # compatibility
+    (trelloize_filename(aha_attachment.file_name) == trello_filename ||
+      aha_attachment.file_name == trello_filename
+    ) && aha_attachment.file_size.to_i == trello_attachment.bytes.to_i
+  end
+
+  def trelloize_filename(fname)
+    URI.encode(fname.gsub(/[ *\\\"\']/, "_"))
   end
 
   def upload_attachments(attachments, card)

--- a/spec/services/trello_spec.rb
+++ b/spec/services/trello_spec.rb
@@ -167,4 +167,10 @@ describe AhaServices::Trello do
     # since one of them is already attached to the card
     expect(create_attachments).to have_been_requested.times(4)
   end
+
+  it "escapes file names properly" do
+    # this filename is the result of aha doing all of its escaping
+    expect(service.trelloize_filename("Screen Shot 2017-06-26 at 9.51.26 AM !______*() -___ __ __ __ _'\"___.__ ī ™.png")).
+      to eq("Screen_Shot_2017-06-26_at_9.51.26_AM_!_______()_-___________________.___i%CC%84_%E2%84%A2.png")
+  end
 end


### PR DESCRIPTION
Please see internal feature for further details

Trello changed its attachment file name normalization. This updates our implementation to match their normalization so that we don't duplicate attachments