### PR TITLE
Allow running on heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "net-http-persistent"
 gem "rubyntlm"
 gem "ClothRed", :git => "https://github.com/aha-app/ClothRed", require: "clothred"
 gem "nokogiri", "1.6.6.2"
+gem "unicorn"
 
 # Auto reload sinatra
 gem "rerun"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GIT
 PATH
   remote: .
   specs:
-    aha-services (1.24.31)
+    aha-services (1.24.33)
       activesupport
       aha-api
       crack
@@ -96,6 +96,7 @@ GEM
     i18n (0.6.11)
     json (1.8.3)
     jwt (1.5.6)
+    kgio (2.10.0)
     listen (2.7.11)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -113,6 +114,7 @@ GEM
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
+    raindrops (0.18.0)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -155,6 +157,9 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
+    unicorn (5.3.0)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     webmock (1.20.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -182,6 +187,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubyntlm
   sinatra
+  unicorn
   webmock
 
 RUBY VERSION

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec unicorn config.ru -p $PORT

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Aha! instance.
   
     ```
     bundle
-    rerun ./bin/proxy_server
+    PORT=4567 foreman start
     ```
     
 2. In another terminal window start a tunnel to your running proxy server so that Aha! can access it, e.g. using ngrok:

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,4 @@
+require "rack"
+require File.expand_path("../lib/proxy/server", __FILE__)
+
+run ProxyApp

--- a/lib/proxy/server.rb
+++ b/lib/proxy/server.rb
@@ -10,7 +10,7 @@ require File.expand_path("../../aha-services.rb", __FILE__)
 #
 class ProxyApp < Sinatra::Base
   enable :logging, :lock
-  set :server, :webrick
+  # set :server, :webrick
   
   #
   # Configure the server.
@@ -114,7 +114,5 @@ class ProxyApp < Sinatra::Base
       true
     end
   end
-  
-  run!
 end
 

--- a/lib/proxy/server.rb
+++ b/lib/proxy/server.rb
@@ -10,8 +10,6 @@ require File.expand_path("../../aha-services.rb", __FILE__)
 #
 class ProxyApp < Sinatra::Base
   enable :logging, :lock
-  # set :server, :webrick
-  
   #
   # Configure the server.
   #


### PR DESCRIPTION
Set up a procfile, config.ru, and tweak the proxy server to allow
running easily on Heroku for users who want to use custom code but do
not want to stand up a server to handle it.