### PR TITLE
APP-4677: Fix nil found_resource for trello board resource

### DIFF
--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.28"
+  VERSION = "1.24.29"
 end

--- a/lib/services/trello/trello_board_resource.rb
+++ b/lib/services/trello/trello_board_resource.rb
@@ -2,7 +2,7 @@ class TrelloBoardResource < TrelloResource
   def all
     prepare_request
     response = http_get trello_url("members/me/boards?lists=all")
-    found_resource(response).collect do |board|
+    Array(found_resource(response)).collect do |board|
       {id: board.id, name: board.name, lists: board.lists.collect {|list| 
         if list.closed
           nil


### PR DESCRIPTION
found_resource can be `nil` in some case (https://sentry.io/aha-labs-inc/aha-production/issues/303066013/).
Coercing to an array keeps the existing functionilty, but protects
against nil.
