### PR TITLE
Adjusts github integration to only accept payloads from intended repo.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GIT
 PATH
   remote: .
   specs:
-    aha-services (1.24.30)
+    aha-services (1.24.31)
       activesupport
       aha-api
       crack

--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.30"
+  VERSION = "1.24.31"
 end

--- a/lib/services/github_issues.rb
+++ b/lib/services/github_issues.rb
@@ -69,9 +69,10 @@ class AhaServices::GithubIssues < AhaService
 
   def receive_webhook
     return unless payload.webhook
-    action = payload.webhook.action
-    issue = payload.webhook.issue
-    return unless issue and action
+    action, issue, repo = payload.webhook.action, payload.webhook.issue, payload.webhook.repository
+    return unless issue and action and repo
+    return unless repo.full_name == data.repository
+    
     results = api.search_integration_fields(data.integration_id, "number", issue.number)['records'] rescue []
     # only consider requirements or features. It is possible for a release to have
     # an issue number that matches a feature and a release - only consider the feature


### PR DESCRIPTION
Currently if someone sets up the integration webhook on the wrong repo,
the integration tries to link with that wrong repo's issues to Aha!
features. This adds a check to ensure we only accept from the right
source.