### PR TITLE
Fix trello spec (inc. exercise update path)

### DIFF
--- a/spec/fixtures/update_feature_event.json
+++ b/spec/fixtures/update_feature_event.json
@@ -96,6 +96,7 @@
         "id": "61280369",
         "name": "id",
         "value": "dummy_trello_card_id",
+        "integration_id": "dummy_trello_integration_id",
         "service_name": "trello"
       },
       {
@@ -184,13 +185,13 @@
           {
             "id": "18669867",
             "name": "id",
-            "value": "dummy_trello_checklist_item_id",
+            "value": "dummy_trello_checklist_item_id",            
             "service_name": "trello"
           },
           {
             "id": "18669868",
             "name": "checklist_id",
-            "value": "dummy_trello_checklist_id",
+            "value": "dummy_trello_checklist_id",            
             "service_name": "trello"
           },
           {

--- a/spec/services/trello_spec.rb
+++ b/spec/services/trello_spec.rb
@@ -6,11 +6,12 @@ describe AhaServices::Trello do
   let(:base_url) { "https://api.trello.com/1" }
   let(:oauth_key) { "my_key" }
   let(:oauth_token) { "my_token" }
+  let(:feature_integration_id) { "dummy_trello_integration_id" }
   let(:service) do
-    AhaServices::Trello.new "server_url" => base_url, "integration_id" => 111
+    AhaServices::Trello.new "server_url" => base_url, "integration_id" => :feature_integration_id
   end
 
-  let(:card_id) { "dummy_trello_card_id" }
+  let(:card_id) { "dummy_trello_card_id" }  
   let(:checklist_id) { "dummy_trello_checklist_id" }
   let(:checklist_item_id) { "dummy_trello_checklist_item_id" }
   let(:callback_url) { "http://some_url.com"}
@@ -22,29 +23,26 @@ describe AhaServices::Trello do
     "#{base_url}/#{path}?key=#{oauth_key}&token=#{oauth_token}"
   end
 
-  before do
-    service.data.stub(:create_features_at).and_return("bottom")
-    service.data.stub(:list_for_new_features).and_return("list_id1")
-    service.data.stub(:oauth_key).and_return(oauth_key)
-    service.data.stub(:oauth_token).and_return(oauth_token)
-    service.data.stub(:callback_url).and_return(callback_url)
-    service.data.stub(:feature_statuses).and_return(feature_statuses)
-  end
-
-  it "can receive new features" do
-    new_feature_event = Hashie::Mash.new(json_fixture("create_feature_event.json"))
-    service.stub(:payload).and_return(new_feature_event)
-    new_feature = new_feature_event.feature
-
-    create_card = stub_request(:post, trello_url("cards"))
+  def stub_requests
+    WebMock.reset!
+    new_feature = @new_feature_event.feature
+    updated_feature = @update_feature_event.feature    
+    # cards        
+    @create_card = stub_request(:post, trello_url("cards"))
       .to_return(status: 200, body: {id: card_id}.to_json)
-    create_webhook = stub_request(:post, trello_url("webhooks"))
+    @get_card = stub_request(:get, trello_url("cards/#{card_id}"))
+      .to_return(status: 200, body: {id: card_id}.to_json)
+    @save_card = stub_request(:put, trello_url("cards/#{card_id}"))
+      .to_return(status: 200)
+    # webhook
+    @create_webhook = stub_request(:post, trello_url("webhooks"))
       .with(body: {
         callbackURL: "#{callback_url}?feature=PROD-2",
         idModel: card_id
       }.to_json)
       .to_return(status: 200)
-    integrate_feature_with_card = stub_request(:post, "#{aha_api_url}/features/#{new_feature.reference_num}/integrations/111/fields")
+    # aha feature integration
+    @integrate_feature_with_card = stub_request(:post, "#{aha_api_url}/features/#{new_feature.reference_num}/integrations/#{feature_integration_id}/fields")
       .with(body: {
         integration_fields: [
           {
@@ -58,26 +56,37 @@ describe AhaServices::Trello do
         ]
       })
       .to_return(status: 200)
-    create_comment = stub_request(:post, trello_url("cards/#{card_id}/actions/comments"))
+    # comments
+    @create_comment = stub_request(:post, trello_url("cards/#{card_id}/actions/comments"))
       .with(body: { text: "Created from Aha! #{new_feature.url}" }.to_json)
       .to_return(status: 200)
-    get_checklists = stub_request(:get, trello_url("cards/#{card_id}/checklists"))
+    # checklists      
+    @get_checklists = stub_request(:get, trello_url("cards/#{card_id}/checklists"))
       .to_return(status: 200, body: "[]")
-    create_checklist = stub_request(:post, trello_url("checklists"))
+    @create_checklist = stub_request(:post, trello_url("checklists"))
       .with(body: {
         idCard: card_id,
         name: "Requirements"
       }.to_json)
       .to_return(status: 200, body: {id: checklist_id}.to_json)
-    create_checklist_item = stub_request(:post, trello_url("checklists/#{checklist_id}/checkItems"))
+    # checklist items
+    @create_checklist_item = stub_request(:post, trello_url("checklists/#{checklist_id}/checkItems"))
       .with(body: {
         idChecklist: checklist_id,
         name: "Requirement 1. First requirement\n\n"
       }.to_json)
       .to_return(status: 200, body: {id: checklist_item_id}.to_json)
-    integrate_requirement_with_checklist_item = stub_request(:post, "#{aha_api_url}/requirements/#{new_feature.requirements[0].reference_num}/integrations/111/fields")
-    .with(body: {
-      integration_fields: [
+    # checklist items
+    @save_checklist_item = stub_request(:post, trello_url("checklists/#{checklist_id}/checkItems"))
+      .with(body: {
+        idChecklist: checklist_id,
+        name: "Requirement 1. First requirement  \n, changed\n\n"
+      }.to_json)
+      .to_return(status: 200, body: {id: checklist_item_id}.to_json)
+    # aha requirements integration
+    @integrate_requirement_with_checklist_item = stub_request(:post, "#{aha_api_url}/requirements/#{new_feature.requirements[0].reference_num}/integrations/#{feature_integration_id}/fields")
+      .with(body: {
+        integration_fields: [
         {
           name: "id",
           value: checklist_item_id
@@ -88,12 +97,12 @@ describe AhaServices::Trello do
         }
       ]
     })
-    get_attachments = stub_request(:get, trello_url("cards/#{card_id}/attachments"))
+    # attachments
+    @get_attachments = stub_request(:get, trello_url("cards/#{card_id}/attachments"))
       .to_return(status: 200, body: "[]")
-    create_attachment = stub_request(:post, trello_url("cards/#{card_id}/attachments"))
-      .to_return(status: 200)
-      
-    # Attachments
+    @create_attachment = stub_request(:post, trello_url("cards/#{card_id}/attachments"))
+      .to_return(status: 200)  
+    # attachment resources
     stub_request(:get, "https://attachments.s3.amazonaws.com/attachments/80641a3d3141ce853ea8642bb6324534fafef5b3/original.png?1370458143").
       to_return(:status => 200, :body => "", :headers => {})
     stub_request(:get, "https://attachments.s3.amazonaws.com/attachments/6fad2068e2aa0e031643d289367263d3721c8683/original.png?1370458145").
@@ -102,70 +111,72 @@ describe AhaServices::Trello do
       to_return(:status => 200, :body => "", :headers => {})
     stub_request(:get, "https://attachments.s3.amazonaws.com/attachments/d1cb788065a70dad7ba481c973e19dcd379eb202/original.png?1370457055").
       to_return(:status => 200, :body => "", :headers => {})
-          
-    service.receive(:create_feature)
 
-    expect(create_card).to have_been_requested.once
-    expect(integrate_feature_with_card).to have_been_requested.once
-    expect(create_comment).to have_been_requested.once
-    expect(get_checklists).to have_been_requested.once
-    expect(create_checklist).to have_been_requested.once
-    expect(create_checklist_item).to have_been_requested.once
-    expect(integrate_requirement_with_checklist_item).to have_been_requested.once
-    # Expecting to issue get_attachments request twice:
-    # first time when handling feature attachments,
-    # second time when handling requirement attachments
-    expect(get_attachments).to have_been_requested.twice
-    # One request for each feature and requirement attachment
-    expect(create_attachment).to have_been_requested.times(4)
   end
 
-  it "can update existing features" do
-    update_feature_event = Hashie::Mash.new(json_fixture("update_feature_event.json"))
-    service.stub(:payload).and_return(update_feature_event)
-    updated_feature = update_feature_event.feature
+  before do    
+    service.data.stub(:create_features_at).and_return("bottom")
+    service.data.stub(:list_for_new_features).and_return("list_id1")
+    service.data.stub(:oauth_key).and_return(oauth_key)
+    service.data.stub(:oauth_token).and_return(oauth_token)
+    service.data.stub(:callback_url).and_return(callback_url)
+    service.data.stub(:feature_statuses).and_return(feature_statuses)
+    service.data.stub(:integration_id).and_return(feature_integration_id)
+    @new_feature_event = Hashie::Mash.new(json_fixture("create_feature_event.json"))    
+    @update_feature_event = Hashie::Mash.new(json_fixture("update_feature_event.json"))
+    stub_requests
+  end
 
-    create_card = stub_request(:post, "https://api.trello.com/1/cards?key=my_key&token=my_token")
-      .to_return(:status => 200, :body => "", :headers => {})
-    stub_request(:post, "https://a.aha.io/api/v1/features/PROD-2/integrations/111/fields")
-      .to_return(:status => 200)
-    stub_request(:post, "https://api.trello.com/1/cards//actions/comments?key=my_key&token=my_token")
-      .to_return(:status => 200)
-    stub_request(:post, "https://api.trello.com/1/cards//actions/comments?key=my_key&token=my_token")
-      .to_return(:status => 200)
-    get_card = stub_request(:get, "https://api.trello.com/1/cards//checklists?key=my_key&token=my_token")
-      .to_return(:status => 200)
-    save_card = stub_request(:post, "https://api.trello.com/1/checklists?key=my_key&token=my_token")
-      .to_return(:status => 200)
-    save_checklist_item = stub_request(:post, "https://api.trello.com/1/checklists//checkItems?key=my_key&token=my_token")
-      .to_return(:status => 200)
-    stub_request(:post, "https://a.aha.io/api/v1/requirements/PROD-2-1/integrations/111/fields")
-      .to_return(:status => 200)
-    get_attachments = stub_request(:get, "https://api.trello.com/1/cards//attachments?key=my_key&token=my_token")
-      .to_return(:status => 200)
-    create_attachments = stub_request(:post, "https://api.trello.com/1/cards//attachments?key=my_key&token=my_token")
-      .to_return(:status => 200)
+  describe "receiving new features" do
 
-    # Attachments
-    stub_request(:get, "https://attachments.s3.amazonaws.com/attachments/80641a3d3141ce853ea8642bb6324534fafef5b3/original.png?1370458143").
-      to_return(:status => 200, :body => "", :headers => {})
-    stub_request(:get, "https://attachments.s3.amazonaws.com/attachments/6fad2068e2aa0e031643d289367263d3721c8683/original.png?1370458145").
-      to_return(:status => 200, :body => "", :headers => {})
-    stub_request(:get, "https://attachments.s3.amazonaws.com/attachments/6cce987f6283d15c080e53bba15b1072a7ab5b07/original.png?1370457053").
-      to_return(:status => 200, :body => "", :headers => {})
-    stub_request(:get, "https://attachments.s3.amazonaws.com/attachments/d1cb788065a70dad7ba481c973e19dcd379eb202/original.png?1370457055").
-      to_return(:status => 200, :body => "", :headers => {})
+    before do
+      service.stub(:payload).and_return(@new_feature_event)      
+      service.receive(:create_feature)
+    end
 
-    service.receive(:update_feature)
+    it "creates cards, comments, checklists and attachments" do
+      expect(@create_card).to have_been_requested.once
+      expect(@create_comment).to have_been_requested.once
+      expect(@get_checklists).to have_been_requested.once
+      expect(@create_checklist).to have_been_requested.once
+      expect(@create_checklist_item).to have_been_requested.once
+      # Expecting to issue get_attachments request twice:
+      # first time when handling feature attachments,
+      # second time when handling requirement attachments
+      expect(@get_attachments).to have_been_requested.twice
+      # One request for each feature and requirement attachment
+      expect(@create_attachment).to have_been_requested.times(4)
+    end
 
-    expect(get_card).to have_been_requested.once
-    expect(save_card).to have_been_requested.once
-    # Checking if the checklist item integrated with the requirement exists
-    expect(save_checklist_item).to have_been_requested.once
-    expect(get_attachments).to have_been_requested.twice
-    # We are expecting only three of four attachments to be uploaded
-    # since one of them is already attached to the card
-    expect(create_attachments).to have_been_requested.times(4)
+    it "integrates features and requirements" do
+      expect(@integrate_feature_with_card).to have_been_requested.once
+      expect(@integrate_requirement_with_checklist_item).to have_been_requested.once
+    end
+
+  end
+
+  describe "updating an existing feature" do
+    
+    before do
+        service.stub(:payload).and_return(@update_feature_event)
+        # but lets pretend that 1 of these attachments already exists
+        @get_attachments = stub_request(:get, trello_url("cards/#{card_id}/attachments"))
+          .to_return(status: 200, body: [{ 
+            url: "https://somedomain.com/Belgium.png",
+            bytes: 28228
+          }].to_json)                  
+        service.receive(:update_feature)        
+    end
+
+    it "saves the card, checklist item and attachments" do            
+      expect(@save_card).to have_been_requested.once
+      # Checking if the checklist item integrated with the requirement was updated
+      expect(@save_checklist_item).to have_been_requested.once      
+      # We are expecting only three of four attachments to be uploaded
+      # since one of them is already attached to the card
+      expect(@create_attachment).to have_been_requested.times(3)
+    end    
+
   end
 
   it "escapes file names properly" do
@@ -173,4 +184,5 @@ describe AhaServices::Trello do
     expect(service.trelloize_filename("Screen Shot 2017-06-26 at 9.51.26 AM !______*() -___ __ __ __ _'\"___.__ ī ™.png")).
       to eq("Screen_Shot_2017-06-26_at_9.51.26_AM_!_______()_-___________________.___i%CC%84_%E2%84%A2.png")
   end
+
 end


### PR DESCRIPTION
Fixes #115 
Includes:
1. Update part of the feature now exercises the update path
2. Refactored to stub requests in one place (removed duplication)
3. Fixed logic in update spec to do what the comments indicated (checking for pre-existing attachment)