### PR TITLE
Ability to sync Aha! Release name as a label on a Trello card

### DIFF
--- a/lib/services/trello.rb
+++ b/lib/services/trello.rb
@@ -32,6 +32,7 @@ class AhaServices::Trello < AhaService
     description: "The postfix which will identify labels as an Aha! release label."
   select :release_label_color,
     label: "Label color for releases",
+    description: "The colour of the labels indicating releases. The default colour is Blue."
     collection: ->(meta_data, data) {
       [
         ["Yellow", "yellow"], 

--- a/lib/services/trello/trello_card_resource.rb
+++ b/lib/services/trello/trello_card_resource.rb
@@ -36,4 +36,18 @@ class TrelloCardResource < TrelloResource
     # Don't fail if we can't create webhook.
     logger.warn(e.message)
   end
+
+  def add_label(id, text, color)
+    prepare_request
+    escaped_text = CGI::escape(text)
+    response = http_post trello_url("cards/#{id}/labels?color=#{color}&name=#{escaped_text}")
+    process_response(response, 200)
+  end
+
+  def remove_label(card_id, label_id)
+    prepare_request
+    response = http_delete trello_url("cards/#{card_id}/idLabels/#{label_id}")
+    process_response(response, 200)
+  end
+
 end

--- a/lib/services/trello/trello_label_resource.rb
+++ b/lib/services/trello/trello_label_resource.rb
@@ -1,0 +1,7 @@
+class TrelloLabelResource < TrelloResource
+  def all_for_card(card_id)
+    prepare_request
+    response = http_get trello_url("cards/#{card_id}/labels")
+    found_resource(response)
+  end
+end


### PR DESCRIPTION
This pull request adds the facility to sync Aha! releases to Trello.

Initially, it was thought that the best approach would be to use the Trello "Custom fields" Power-Up to create a custom field on Trello cards which would then be populated with the Aha! release name (and URL). However, the custom fields power up is currently rather limited and does not enable e.g. filtering cards by the content of the custom field. So, it would be impossible to e.g. only show cards for a given release.

On the other hand, the support for Labels in Trello is first-class and supports filtering very nicely. The problem with labels in Trello is that a label can have no extra metadata associated with it (just the the name of the label and its color). So, when needing to update a Trello card with the current Aha! Release label, there was no easy way to identify label(s) to remove from the card before adding the new one.

For this reason, we went with a post-fix approach. By default, release labels are Blue and have a postfix of "(Aha! release)", which serves the following purposes:

1. Promotes awareness of the Aha! brand in the context of the integrated product (as other integrations also do)
2. Allows us to recognise and remove old release labels prior to applying a new one (by matching this postfix against the label's name

The following configuration options are included:
1. Boolean (checkbox) to toggle on syncing of release names as labels
2. String Postfix - can be set to use something other than the default "(Aha! release)"
3. Select Release label color - to choose a release label color other than the default Blue for release labels

