### PR TITLE
Show the full name for gitlab repos

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GIT
 PATH
   remote: .
   specs:
-    aha-services (1.24.33)
+    aha-services (1.24.35)
       activesupport
       aha-api
       crack
@@ -194,4 +194,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.34"
+  VERSION = "1.24.35"
 end

--- a/lib/services/gitlab/gitlab_resource.rb
+++ b/lib/services/gitlab/gitlab_resource.rb
@@ -30,9 +30,6 @@ class GitlabResource < GenericResource
   end
 
   def get_project_id
-    repos = @service.meta_data.repos.select { |repo| repo['full_name'] == @service.data.project }
-    if repos.kind_of?(Array)
-      repos[0].id
-    end
+    @service.get_project&.id
   end
 end


### PR DESCRIPTION
In gitlab, you can create groups that namespace the report. So I could have
aha-app/docs and jjbohn/docs. Our current implementation only showed the repo
name, not the group, so it would just show "doc" twice. This actually made
it impossible to tie it to the correct report as well since we use the name
to map the integration.

This fix shows the full name now and fixes both issues. The problem was that we were using `name` from the API. That never contains the namespace, we need to be using `path_with_namespace`.

It is also backwards compatible. To do this, it checks if the saved
repo name is the full name, or just the repo name, then acts accordingly.

**Before:**
![screen_shot_2017-09-20_at_11_32_12_am](https://user-images.githubusercontent.com/401301/30655631-93fcfd36-9dff-11e7-88c6-9aa5e47bbbd4.png)

**After:**
![screen shot 2017-09-20 at 12 30 03 pm](https://user-images.githubusercontent.com/401301/30655613-880dae9e-9dff-11e7-994b-c854e87a96c3.png)
