### PR TITLE
github-should-ignore-open-actions

### DIFF
--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.45"
+  VERSION = "1.24.46"
 end

--- a/lib/services/github_issues.rb
+++ b/lib/services/github_issues.rb
@@ -138,6 +138,7 @@ class AhaServices::GithubIssues < AhaService
         # use current tags in open state when the workflow status changes
         if action == "opened"
           new_tags.push(*resource.tags)
+          new_tags.uniq!
         end
         label_resource.update(issue.number, [new_tags, workflow_status_to_github_label(updated_resource[resource_kind].workflow_status.name)].flatten) 
       end

--- a/spec/services/github_issues_spec.rb
+++ b/spec/services/github_issues_spec.rb
@@ -622,7 +622,7 @@ describe AhaServices::GithubIssues do
 
           it "should not propagate open labels" do
             service.stub(:payload).and_return(Hashie::Mash.new({label: {name: 'Aha!:Shipped'}, webhook: { action: 'opened', issue: opened_mock_issue, repository: mock_repository }}))
-            label_resource.should_receive(:update).with(opened_mock_issue[:number], ["First", "Second", "Third", "Aha!:In development"])
+            label_resource.should_not_receive(:update)
             service.stub(:label_resource).and_return(label_resource)
             mock_api_client.stub(:put).and_return(Hashie::Mash.new({feature: {workflow_status: {name: "In development"}}}))
           end

--- a/spec/services/github_issues_spec.rb
+++ b/spec/services/github_issues_spec.rb
@@ -616,11 +616,20 @@ describe AhaServices::GithubIssues do
         end
 
         context "and opened action" do
-          let(:mock_issue) { { number: 42, title: "The issue", state: "open", labels: [{name:"First"}, {name:"Second"}, {name: "Third"}, {name: "Aha!:Shipped"}] } }
+          let(:closed_mock_issue) { { number: 42, title: "The issue", state: "closed", labels: [{name:"First"}, {name:"Second"}, {name: "Third"}, {name: "Aha!:Shipped"}] } }
+          let(:opened_mock_issue) { { number: 42, title: "The issue", state: "opened", labels: [{name:"First"}, {name:"Second"}, {name: "Third"}, {name: "Aha!:Shipped"}] } }
+
+
+          it "should not propagate open labels" do
+            service.stub(:payload).and_return(Hashie::Mash.new({label: {name: 'Aha!:Shipped'}, webhook: { action: 'opened', issue: opened_mock_issue, repository: mock_repository }}))
+            label_resource.should_receive(:update).with(opened_mock_issue[:number], ["First", "Second", "Third", "Aha!:In development"])
+            service.stub(:label_resource).and_return(label_resource)
+            mock_api_client.stub(:put).and_return(Hashie::Mash.new({feature: {workflow_status: {name: "In development"}}}))
+          end
 
           it "should propagate the open status back to GitHub" do
-            service.stub(:payload).and_return(Hashie::Mash.new({label: {name: 'Aha!:Shipped'}, webhook: { action: 'opened', issue: mock_issue, repository: mock_repository }}))
-            label_resource.should_receive(:update).with(mock_issue[:number], ["First", "Second", "Third", "Aha!:In development"])
+            service.stub(:payload).and_return(Hashie::Mash.new({label: {name: 'Aha!:Shipped'}, webhook: { action: 'opened', issue: closed_mock_issue, repository: mock_repository }}))
+            label_resource.should_receive(:update).with(closed_mock_issue[:number], ["First", "Second", "Third", "Aha!:In development"])
             service.stub(:label_resource).and_return(label_resource)
             mock_api_client.stub(:put).and_return(Hashie::Mash.new({feature: {workflow_status: {name: "In development"}}}))
           end


### PR DESCRIPTION
Dearest Reviewer

Do not listen to the opened action when setting tags. They are not
there yet.

Changes

Do not sync tags for the open action
When sending and it is a create always send the open status

Becker