### PR TITLE
prevent-double-slash-in-github-url

### DIFF
--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.46"
+  VERSION = "1.24.47"
 end

--- a/lib/services/github_issues.rb
+++ b/lib/services/github_issues.rb
@@ -342,14 +342,27 @@ protected
     end
   end
 
+  def github_url(paths, query = {})
+    paths = [ data.repository.split("/"), *paths.map{|path| path.split("/")}].flatten
+    paths.reject!(&:empty?)
+    server_slash = server_display_url =~ /\/\z/ ? "" : "/"
+    url_string = server_display_url + server_slash + paths.join("/")
+    url = URI.parse(url_string)
+    if query.present?
+      url.query= URI.encode_www_form(query)
+    end
+    url.to_s
+  end
+
   def integrate_release_with_github_milestone(release, milestone)
     api.create_integration_fields("releases", release.reference_num, data.integration_id,
-      {number: milestone['number'], url: "#{server_display_url}/#{data.repository}/issues?milestone=#{milestone['number']}"})
+      {number: milestone['number'], url: github_url(["issues"], {"milestone"=>milestone['number']})})
   end
 
   def integrate_resource_with_github_issue(resource, issue)
+    
     api.create_integration_fields(reference_num_to_resource_type(resource.reference_num), resource.reference_num, data.integration_id,
-      {number: issue['number'], url: "#{server_display_url}/#{data.repository}/issues/#{issue['number']}"})
+      {number: issue['number'], url: github_url(["issues", issue['number']])})
   end
 
   def requirements_to_checklist?

--- a/lib/services/github_issues.rb
+++ b/lib/services/github_issues.rb
@@ -343,13 +343,13 @@ protected
   end
 
   def github_url(paths, query = {})
-    paths = [ data.repository.split("/"), *paths.map{|path| path.split("/")}].flatten
+    paths = [data.repository.split("/"), *paths.map{|path| path.split("/")}].flatten
     paths.reject!(&:empty?)
     server_slash = server_display_url =~ /\/\z/ ? "" : "/"
     url_string = server_display_url + server_slash + paths.join("/")
     url = URI.parse(url_string)
     if query.present?
-      url.query= URI.encode_www_form(query)
+      url.query = URI.encode_www_form(query)
     end
     url.to_s
   end

--- a/spec/services/github_issues_spec.rb
+++ b/spec/services/github_issues_spec.rb
@@ -120,6 +120,20 @@ describe AhaServices::GithubIssues do
     end
   end
 
+  describe "#github_url" do
+    it "builts url" do
+      expect(service.send(:github_url, ["a"])).to eq("https://api.github.com/user/repo/a")
+    end
+
+    it "with params" do
+      expect(service.send(:github_url, ["a"], {"b" => "c", "d" => "e"})).to eq("https://api.github.com/user/repo/a?b=c&d=e")
+    end
+
+    it "with extra slashes" do
+      expect(service.send(:github_url, ["/a","/b/"])).to eq("https://api.github.com/user/repo/a/b")
+    end
+  end
+
   describe "#update_or_attach_github_milestone" do
     let(:mock_milestone) { { number: 42 } }
     context "when the release is integrated with a github milestone" do

--- a/spec/services/github_issues_spec.rb
+++ b/spec/services/github_issues_spec.rb
@@ -121,7 +121,7 @@ describe AhaServices::GithubIssues do
   end
 
   describe "#github_url" do
-    it "builts url" do
+    it "builds url" do
       expect(service.send(:github_url, ["a"])).to eq("https://api.github.com/user/repo/a")
     end
 


### PR DESCRIPTION
Dearest Reviewer,

The internet is to picky when it comes to locations..

Changes
Consolidate url generation in github
I did not use URI.join like I wanted to because it does not work
like you want it to. Splits and joins seemed the best bet.

Becker