### PR TITLE
Send tags to GitHub on initial issue creation.

### DIFF
--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.46"
+  VERSION = "1.24.47"
 end

--- a/lib/services/github_issues.rb
+++ b/lib/services/github_issues.rb
@@ -239,17 +239,21 @@ class AhaServices::GithubIssues < AhaService
 
   def create_issue_for(resource, milestone)
     issue_resource
-      .create(title: resource_name(resource),
-              body: issue_body(resource),
-              milestone: milestone['number'])
-      .tap { |issue| update_labels(issue, resource, true) }
+      .create({
+        title: resource_name(resource),
+        body: issue_body(resource),
+        milestone: milestone['number'],
+        labels: resource&.tags.dup # Send the normal tags immediately so we don't thrash them with a webhook
+      }).tap { |issue| update_labels(issue, resource, true) }
   end
 
   def update_issue(number, resource, milestone)
     issue_resource
-      .update(number, title: resource_name(resource),
-                      body: issue_body(resource),
-                      milestone: milestone['number'])
+      .update(number, {
+        title: resource_name(resource),
+        body: issue_body(resource),
+        milestone: milestone['number']
+      })
       .tap { |issue| update_labels(issue, resource) }
       .tap { |issue| update_issue_status(issue, resource)}
   end


### PR DESCRIPTION
If we don't send the tags immediately, and they have a webhook set up, it is possible for the initial creation to trigger a webhook which clears the tags in aha

https://big.aha.io/features/APP-5806