### PR TITLE
allow-numbers-in-github-urls

### DIFF
--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.49"
+  VERSION = "1.24.50"
 end

--- a/lib/services/github_issues.rb
+++ b/lib/services/github_issues.rb
@@ -347,7 +347,7 @@ protected
   end
 
   def github_url(paths, query = {})
-    paths = [data.repository.split("/"), *paths.map{|path| path.split("/")}].flatten
+    paths = [data.repository.split("/"), *paths.map{|path| path.to_s.split("/")}].flatten
     paths.reject!(&:empty?)
     server_slash = server_display_url =~ /\/\z/ ? "" : "/"
     url_string = server_display_url + server_slash + paths.join("/")

--- a/spec/services/github_issues_spec.rb
+++ b/spec/services/github_issues_spec.rb
@@ -125,6 +125,10 @@ describe AhaServices::GithubIssues do
       expect(service.send(:github_url, ["a"])).to eq("https://api.github.com/user/repo/a")
     end
 
+    it "builds url with numbers" do
+      expect(service.send(:github_url, ["a", 33])).to eq("https://api.github.com/user/repo/a/33")
+    end
+
     it "with params" do
       expect(service.send(:github_url, ["a"], {"b" => "c", "d" => "e"})).to eq("https://api.github.com/user/repo/a?b=c&d=e")
     end


### PR DESCRIPTION
Dearest Reviewer,

It turns out that github returns a number for the issue id and not
a string. I am not sure what math we will do with the id but when
generating urls we dont care.

Changes:
Adds a to_s to the paths the code builds out
Adds a test
Bumped version number

Becker