### PR TITLE
compacting out nil values from lists in jira sync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GIT
 PATH
   remote: .
   specs:
-    aha-services (1.24.46)
+    aha-services (1.24.51)
       activesupport (< 5)
       aha-api
       crack
@@ -195,4 +195,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.50"
+  VERSION = "1.24.51"
 end

--- a/lib/services/jira/jira_mapped_fields.rb
+++ b/lib/services/jira/jira_mapped_fields.rb
@@ -106,9 +106,9 @@ module JiraMappedFields
   def aha_type_to_array(aha_type, aha_value, jira_type_info)
     values = case aha_type
       when "array"
-        aha_value
+        aha_value.compact
       else
-        [aha_value]
+        [aha_value].compact
       end
 
     # Recurse for the array 


### PR DESCRIPTION
There is a case where `[nil]` is sent to the services gem. when converted, this becomes `[null]`. This causes JIRA to blow up, and syncing to break.