### PR TITLE
Ensure potentially closed features can create closed GH issues.

### DIFF
--- a/lib/services/github_issues.rb
+++ b/lib/services/github_issues.rb
@@ -234,6 +234,7 @@ class AhaServices::GithubIssues < AhaService
   def attach_issue_to(resource, milestone)
     issue = create_issue_for(resource, milestone)
     integrate_resource_with_github_issue(resource, issue)
+    update_issue_status(issue, resource)
     issue
   end
 
@@ -244,7 +245,8 @@ class AhaServices::GithubIssues < AhaService
         body: issue_body(resource),
         milestone: milestone['number'],
         labels: resource&.tags&.dup || []# Send the normal tags immediately so we don't thrash them with a webhook
-      }).tap { |issue| update_labels(issue, resource, true) }
+      })
+      .tap { |issue| update_labels(issue, resource, true) }
   end
 
   def update_issue(number, resource, milestone)


### PR DESCRIPTION
If you have a workflow status mapped to the `closed` GitHub issue state, and send a new feature with that status to GitHub, it still creates the issue as opened initially.

This sucks because that then gets synced back to the Aha! feature as a reason to change its workflow status to whatever GitHub's `open` is mapped to.

This makes sure sending new issues for the first time checks to see if it should 'start' in a closed status. The GitHub API doesn't let you create new issues with any status other than `open`, so we just close it immediately as part of the create flow.