### PR TITLE
APP-6404: Treat sent-from-Aha! GitHub issues specially

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,4 @@ gem "rerun"
 
 # Development proxy debugging
 gem "byebug"
+gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
     byebug (6.0.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
@@ -104,6 +105,7 @@ GEM
       rb-inotify (>= 0.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    method_source (0.9.0)
     mime-types (2.99.2)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
@@ -112,6 +114,9 @@ GEM
     net-http-persistent (2.9.4)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (1.6.8)
     rack-protection (1.5.3)
       rack
@@ -180,6 +185,7 @@ DEPENDENCIES
   net-http-persistent
   nokogiri (~> 1.8)
   plain-david!
+  pry
   redcarpet
   rerun
   restforce

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ When an object is created in a third party system, the integration code can use 
     api.create_integration_fields('features', feature.id, data.integration_id,
       {id: issue.id, key: issue[:key]})
 
+That is, `api.create_integration_fields(resource_type, resource_id, integration_id, data_hash)`
+
 The payload for each feature and release event will contain the integration fields that have previously been set.
 
 Running an integration in development

--- a/spec/services/github_issues_spec.rb
+++ b/spec/services/github_issues_spec.rb
@@ -366,12 +366,27 @@ describe AhaServices::GithubIssues do
   end
 
   describe "#create_issue_for" do
+    let(:api_client) { double(:api_client) }
+    before do
+      service.stub(:api).and_return(api_client)
+    end
+    
     it "returns the newly created issue" do
       mock_issue = { title: 'First issue' }
       mock_milestone = { number: 1 }
       service.stub(:update_labels)
       issue_resource.should_receive(:create).and_return(mock_issue)
+      api_client.stub(:create_integration_fields)
       expect(service.create_issue_for(feature, mock_milestone)).to eq mock_issue
+    end
+    
+    it "flags the resource as sent from Aha!" do
+      mock_issue = { title: 'First issue' }
+      mock_milestone = { number: 1 }
+      service.stub(:update_labels)
+      allow(issue_resource).to receive(:create)
+      expect(api_client).to receive(:create_integration_fields).with("features", nil, nil, { "sent_from_aha" => true })
+      service.create_issue_for(feature, mock_milestone)
     end
   end
 
@@ -697,30 +712,27 @@ describe AhaServices::GithubIssues do
     end
   end
   
-  # These are integration tests after fashion, playing out
-  # some ping-pong interactions between Aha! and GitHub.
-  # I've isolated their setup from the tests above so they
-  # are resilient to breakage.
-  
   context "when sending an existing feature to GitHub" do
     
+    let(:integration_id){ "integration_id" }
     let(:service) do
       AhaServices::GithubIssues.new(
         'server_url' => "https://api.github.com",
         'username' => 'user', 'password' => 'secret',
-        'repository' => 'user/repo'
+        'repository' => 'user/repo',
+        'integration_id' => integration_id,
       )
     end
     
-    let(:api_client) { double }
-    let(:milestone_resource) { double }
-    let(:issue_resource) { double }
-    let(:label_resource) { double }
+    let(:api_client) { double(:api_client) }
+    # let(:milestone_resource) { double(:milestone_resource) }
+    let(:issue_resource) { double(:issue_resource) }
+    # let(:label_resource) { double(:label_resource) }
 
     before do
       service.stub(:api).and_return(api_client)
-      service.stub(:milestone_resource).and_return(milestone_resource)
-      service.stub(:issue_resource).and_return(issue_resource)
+      # service.stub(:milestone_resource).and_return(milestone_resource)
+      # service.stub(:issue_resource).and_return(issue_resource)
       service.stub(:label_resource).and_return(label_resource)
     end
     
@@ -733,6 +745,11 @@ describe AhaServices::GithubIssues do
         release: { name: 'Existing Feature Release' },
         tags: [],
         requirements: [],
+        integration_fields: [{
+          integration_id: integration_id,
+          name: "sent_from_aha",
+          value: true
+        }],
       )
     end
     
@@ -740,15 +757,15 @@ describe AhaServices::GithubIssues do
       api_client.stub(:search_integration_fields).and_return(Hashie::Mash.new(records: [
         { feature: aha_feature.merge(resource: 'existing-feature') },
       ]))
-      api_client.stub(:create_integration_fields)
+      # api_client.stub(:create_integration_fields)
     end
     
-    let(:github_milestone) do
-      Hashie::Mash.new(
-        number: 1,
-        title: aha_feature.release.name,
-      )
-    end
+    # let(:github_milestone) do
+    #   Hashie::Mash.new(
+    #     number: 1,
+    #     title: aha_feature.release.name,
+    #   )
+    # end
     let(:github_issue) do
       Hashie::Mash.new(
         number: 1,
@@ -757,6 +774,7 @@ describe AhaServices::GithubIssues do
         state: "open", # New issues always start open
       )
     end
+    
     let(:github_webhook) do
       Hashie::Mash.new(
         action: 'opened', # New issues always fire opened webhook
@@ -764,28 +782,8 @@ describe AhaServices::GithubIssues do
         repository: { full_name: 'user/repo' },
       )
     end
-    
     before do
-      milestone_resource.stub(:find_by_title).and_return(nil)
-      milestone_resource.stub(:create).and_return(github_milestone)
-      issue_resource.stub(:create).and_return(github_issue)
-      label_resource.stub(:update)
-    end
-    
-    def trigger_feature_send
-      service.stub(:payload).and_return(Hashie::Mash.new(feature: aha_feature))
-      service.receive_create_feature
-    end
-    
-    def trigger_issue_receive
       service.stub(:payload).and_return(Hashie::Mash.new(webhook: github_webhook))
-      service.receive_webhook
-    end
-    
-    def send_to_github
-      trigger_feature_send
-      yield
-      trigger_issue_receive
     end
     
     context "with mapped workflow statuses" do
@@ -797,15 +795,13 @@ describe AhaServices::GithubIssues do
         let(:workflow_status) { { id: '12345' } }
         
         it "leaves the feature as open" do
-          send_to_github do
-            expect(api_client).to_not receive(:put)
-          end
+          expect(api_client).to_not receive(:put)
+          service.receive_webhook
         end
         
         it "doesn't try to needlessly re-update the issue status" do
-          send_to_github do
-            expect(issue_resource).to_not receive(:update)
-          end
+          expect(issue_resource).to_not receive(:update)
+          service.receive_webhook
         end
       end
       
@@ -813,16 +809,14 @@ describe AhaServices::GithubIssues do
         let(:workflow_status) { { id: '67890' } }
         
         it "leaves the feature as closed" do
-          send_to_github do
-            allow(issue_resource).to receive(:update)
-            expect(api_client).to_not receive(:put)
-          end
+          allow(issue_resource).to receive(:update)
+          expect(api_client).to_not receive(:put)
+          service.receive_webhook
         end
         
         it "remembers to go back and close the issue" do
-          send_to_github do
-            expect(issue_resource).to receive(:update)
-          end
+          expect(issue_resource).to receive(:update)
+          service.receive_webhook
         end
       end
       
@@ -830,15 +824,13 @@ describe AhaServices::GithubIssues do
         let(:workflow_status) { { id: '404' } }
         
         it "leaves the feature status alone" do
-          send_to_github do
-            expect(api_client).to_not receive(:put)
-          end
+          expect(api_client).to_not receive(:put)
+          service.receive_webhook
         end
         
         it "does not try to modify the issue status" do
-          send_to_github do
-            expect(issue_resource).to_not receive(:update)
-          end
+          expect(issue_resource).to_not receive(:update)
+          service.receive_webhook
         end
       end
     end
@@ -851,15 +843,13 @@ describe AhaServices::GithubIssues do
       let(:workflow_status) { { id: '9001' } }
       
       it "leaves the feature status alone" do
-        send_to_github do
-          expect(api_client).to_not receive(:put)
-        end
+        expect(api_client).to_not receive(:put)
+        service.receive_webhook
       end
       
       it "does not try to modify the issue status" do
-        send_to_github do
-          expect(issue_resource).to_not receive(:update)
-        end
+        expect(issue_resource).to_not receive(:update)
+        service.receive_webhook
       end
     end
     


### PR DESCRIPTION
GitHub issues *always* are created as opened. When existing features are sent to create new issues in GitHub, they always immediately propagate back to Aha! in webhooks, overriding feature statuses, if they were anything other than whatever workflow status was mapped to 'open'.

This flags issues being created from Aha! so that when we receive the corresponding "opened" webhooks, we know whom to defer to for the authoritative source of truth about the current status of the item.

Feature: [APP-6404](https://big.aha.io/features/APP-6404)