### PR TITLE
Update feature state when issue is reopened

### DIFF
--- a/lib/aha-services/version.rb
+++ b/lib/aha-services/version.rb
@@ -1,3 +1,3 @@
 module AhaServices
-  VERSION = "1.24.54"
+  VERSION = "1.24.55"
 end

--- a/lib/services/gitlab_issues.rb
+++ b/lib/services/gitlab_issues.rb
@@ -116,7 +116,7 @@ class AhaServices::GitlabIssues < AhaService
       diff[:tags] = new_tags unless resource.tags && resource.tags.sort == new_tags.sort
 
     when "close", "open", "reopen"
-      new_state = (objattr.state == "reopened") ? "open" : objattr.state
+      new_state = (["reopened", "opened"].include?(objattr.state)) ? "open" : objattr.state
       new_status = data.status_mapping.nil? ? nil : data.status_mapping[new_state]
       diff[:workflow_status] = new_status if new_status.present? && new_status != resource.workflow_status.id
     end


### PR DESCRIPTION
support ticket: https://ahasupport.zendesk.com/agent/tickets/194756

Gitlab may have changed the string that they are sending. It seems like "opened" is being used rather than "reopened", when an issue is reopened. So we just check for either.