### PR TITLE
App 6984 google hangouts chat

### DIFF
--- a/docs/google_hangouts_chat.md
+++ b/docs/google_hangouts_chat.md
@@ -1,10 +1,11 @@
-Send product notifications from Aha! to Google Hangouts Chat.
+Send a log of activity from Aha! to a Google Hangouts Chat room. Configure the integration for a product to send only activity for that product. Configure the integration for the account to send all activity that you have access to.
 
 **WARNING** Sending activity from Aha! into Google Hangouts Chat bypasses the security controls in your Aha! account. Anyone who has access to your Google Hangouts Chat room will be able to see the activity, regardless of whether they have access to that information in Aha!
 
 ## Configuration
 
-### Create a webhook in Google Hangouts Chat
+Create a webhook in Google Hangouts
+
 1. Open your room in Google Hangouts Chat then click on the room name.
 1. Click Configure webhooks, then Add webhook.
 1. Name your webhook (e.g. Aha! product updates.)
@@ -12,8 +13,13 @@ Send product notifications from Aha! to Google Hangouts Chat.
 1. Save the webhook.
 1. Copy the webhook URL
 
-### Create the integration in Aha!
+Create the integration in Aha!
+
 1. Enter the URL into the _Webhook URL_ field.
+1. Click the Test connection button. After a short delay you should see a message appear in the Google Hangouts Chat room you copied the webhook from.
+1. Customize the channel by selecting the activities which you would like to appear in your Google Hangouts Chat room.
+1. Enable the integration.
+1. Consider renaming this integration with your Google Hangouts Chat room name for easy future reference. Perhaps something like: "Google Hangouts: #customers." You can do this by clicking the Google Hangouts Chat text in the heading of this page.
 
 ## Troubleshooting
 

--- a/docs/google_hangouts_chat.md
+++ b/docs/google_hangouts_chat.md
@@ -1,0 +1,16 @@
+Send a log of activity from Aha! to a Google Hangouts Chat room. Configure the integration for a product to send only activity for that product. Configure the integration for the account to send all activity that you have access to.
+
+**WARNING** Sending activity out of Aha! and into Google Hangouts Chat bypasses the security controls in Aha!. Anyone who has access to your Slack channel will be able to see the activity, regardless of whether they have access to that information in Aha!
+
+## Configuration
+
+1. When creating your webhook add: `https://secure.aha.io/assets/logos/aha_square_300.png` as the webhook image
+1. Copy your webhook URL
+1. Click the _Test connection_ button. After a short delay you should see a message appear in the Google Hangouts Chat room you copied the webhook from.
+1. Customize the channel by selecting the activities which you would like to appear in your Google Hangouts Chat room.
+1. Enable the integration.
+1. Consider renaming this integration with your Google Hangouts Chat room name for easy future reference. Perhaps something like: "Google Hangouts: #customers." You can do this by clicking the _Google Hangouts Chat_ text in the heading of this page.
+
+## Troubleshooting
+
+To help you troubleshoot an error, we provide the detailed integration logs below. Contact us at support@aha.io if you need further help.

--- a/docs/google_hangouts_chat.md
+++ b/docs/google_hangouts_chat.md
@@ -1,15 +1,19 @@
-Send a log of activity from Aha! to a Google Hangouts Chat room. Configure the integration for a product to send only activity for that product. Configure the integration for the account to send all activity that you have access to.
+Send product notifications from Aha! to Google Hangouts Chat.
 
-**WARNING** Sending activity out of Aha! and into Google Hangouts Chat bypasses the security controls in Aha!. Anyone who has access to your Slack channel will be able to see the activity, regardless of whether they have access to that information in Aha!
+**WARNING** Sending activity from Aha! into Google Hangouts Chat bypasses the security controls in your Aha! account. Anyone who has access to your Google Hangouts Chat room will be able to see the activity, regardless of whether they have access to that information in Aha!
 
 ## Configuration
 
-1. When creating your webhook add: `https://secure.aha.io/assets/logos/aha_square_300.png` as the webhook image
-1. Copy your webhook URL
-1. Click the _Test connection_ button. After a short delay you should see a message appear in the Google Hangouts Chat room you copied the webhook from.
-1. Customize the channel by selecting the activities which you would like to appear in your Google Hangouts Chat room.
-1. Enable the integration.
-1. Consider renaming this integration with your Google Hangouts Chat room name for easy future reference. Perhaps something like: "Google Hangouts: #customers." You can do this by clicking the _Google Hangouts Chat_ text in the heading of this page.
+### Create a webhook in Google Hangouts Chat
+1. Open your room in Google Hangouts Chat then click on the room name.
+1. Click Configure webhooks, then Add webhook.
+1. Name your webhook (e.g. Aha! product updates.)
+1. Enter `https://www.aha.io/aha_square_300.png` into the Avatar URL field.
+1. Save the webhook.
+1. Copy the webhook URL
+
+### Create the integration in Aha!
+1. Enter the URL into the _Webhook URL_ field.
 
 ## Troubleshooting
 

--- a/lib/services/flowdock.rb
+++ b/lib/services/flowdock.rb
@@ -1,5 +1,5 @@
 class AhaServices::Flowdock < AhaService
-  caption "Send customized activity from Aha! into group chat"
+  caption "Send product notifications from Aha! to Flowdock"
   category "Communication"
   
   string :flow_api_token,

--- a/lib/services/google_hangouts_chat.rb
+++ b/lib/services/google_hangouts_chat.rb
@@ -30,39 +30,38 @@ class AhaServices::GoogleHangoutsChat < AhaService
 
     description = [user, audit.description].join(' ')
       
+    title_section = {
+      widgets: [ { textParagraph: { text: description } } ]
+    }
+
     kvs = audit.changes.map do |change|
-      { keyValue: { topLabel: change["field_name"], content: change["value"], contentMultiline: true } }
+      { keyValue: { topLabel: change["field_name"], content: change["value"].to_s, contentMultiline: "true" } }
     end
-    send_message(
-      cards: [
+
+    update_section = {
+      widgets: kvs
+    }
+
+    link_section = {
+      widgets: [
         {
-          sections: [
+          buttons: [
             {
-              widgets: [ { textParagraph: { text: description } } ]
-            },
-            {
-              widgets: kvs
-            },
-            {
-              widgets: [
-                {
-                  buttons: [
-                    {
-                      textButton: {
-                        text: "GO TO OBJECT",
-                        onClick: {
-                          openLink: { url: audit.auditable_url }
-                        }
-                      }
-                    }
-                  ]
+              textButton: {
+                text: "GO TO OBJECT",
+                onClick: {
+                  openLink: { url: audit.auditable_url }
                 }
-              ]
+              }
             }
           ]
         }
       ]
-    )
+    }
+
+    sections = kvs.empty? ? [title_section, link_section] : [title_section, update_section, link_section]
+    message = { cards: [ { sections: sections } ] }
+    send_message(message)
   end
     
   

--- a/lib/services/google_hangouts_chat.rb
+++ b/lib/services/google_hangouts_chat.rb
@@ -29,10 +29,8 @@ class AhaServices::GoogleHangoutsChat < AhaService
     }
 
     kvs = audit.changes.map do |change|
-      frag = Nokogiri::HTML.fragment(change["value"].to_s)
-      frag.css('.deleted').each { |el| el.name= "font"; el.set_attribute("color" , "#9d261d") } # modifies frag in place
-      frag.css('.inserted').each { |el| el.name= "font"; el.set_attribute("color" , "#46a546") } # modifies frag in place
-      { keyValue: { topLabel: change["field_name"], content: frag.to_html, contentMultiline: "true" } }
+      content = html_change_colors(change["value"])
+      { keyValue: { topLabel: change["field_name"], content: content, contentMultiline: "true" } }
     end
 
     update_section = {
@@ -60,12 +58,14 @@ class AhaServices::GoogleHangoutsChat < AhaService
     message = { cards: [ { sections: sections } ] }
     send_message(message)
   end
-    
   
 protected
 
-  def is_wide_field(field_name)
-    !["Description", "Theme", "Body"].include?(field_name)
+  def html_change_colors(val)
+    frag = Nokogiri::HTML.fragment(val.to_s)
+    frag.css('.deleted').each { |el| el.name= "font"; el.set_attribute("color" , "#9d261d") } # modifies frag in place
+    frag.css('.inserted').each { |el| el.name= "font"; el.set_attribute("color" , "#46a546") } # modifies frag in place
+    frag.to_html
   end
 
   def url

--- a/lib/services/google_hangouts_chat.rb
+++ b/lib/services/google_hangouts_chat.rb
@@ -3,7 +3,7 @@ class AhaServices::GoogleHangoutsChat < AhaService
   category "Communication"
   
   string :google_hangouts_chat_webhook_url,
-    description: "The webhook that you copied from the room"
+    description: "The URL that you copied when creating the webhook in Google Hangouts Chat"
   install_button
   
   audit_filter

--- a/lib/services/google_hangouts_chat.rb
+++ b/lib/services/google_hangouts_chat.rb
@@ -31,7 +31,7 @@ class AhaServices::GoogleHangoutsChat < AhaService
     description = [user, audit.description].join(' ')
       
     kvs = audit.changes.map do |change|
-      { keyValue: { topLabel: change["field_name"], content: change["value"] } }
+      { keyValue: { topLabel: change["field_name"], content: change["value"] contentMultiline: true } }
     end
     send_message(
       cards: [

--- a/lib/services/google_hangouts_chat.rb
+++ b/lib/services/google_hangouts_chat.rb
@@ -31,7 +31,7 @@ class AhaServices::GoogleHangoutsChat < AhaService
     description = [user, audit.description].join(' ')
       
     kvs = audit.changes.map do |change|
-      { keyValue: { topLabel: change["field_name"], content: change["value"] contentMultiline: true } }
+      { keyValue: { topLabel: change["field_name"], content: change["value"], contentMultiline: true } }
     end
     send_message(
       cards: [

--- a/lib/services/google_hangouts_chat.rb
+++ b/lib/services/google_hangouts_chat.rb
@@ -22,20 +22,17 @@ class AhaServices::GoogleHangoutsChat < AhaService
         "Aha!"
       end
     
-    link = if audit.auditable_url
-        "<#{audit.auditable_url}|#{audit.description}>"
-      else
-        audit.description
-      end
-
-    description = [user, audit.description].join(' ')
+    description = "<b>#{user}</b> #{audit.description}"
       
     title_section = {
       widgets: [ { textParagraph: { text: description } } ]
     }
 
     kvs = audit.changes.map do |change|
-      { keyValue: { topLabel: change["field_name"], content: change["value"].to_s, contentMultiline: "true" } }
+      frag = Nokogiri::HTML.fragment(change["value"].to_s)
+      frag.css('.deleted').each { |el| el.name= "font"; el.set_attribute("color" , "#9d261d") } # modifies frag in place
+      frag.css('.inserted').each { |el| el.name= "font"; el.set_attribute("color" , "#46a546") } # modifies frag in place
+      { keyValue: { topLabel: change["field_name"], content: frag.to_html, contentMultiline: "true" } }
     end
 
     update_section = {
@@ -48,7 +45,7 @@ class AhaServices::GoogleHangoutsChat < AhaService
           buttons: [
             {
               textButton: {
-                text: "GO TO OBJECT",
+                text: "VIEW IN AHA!",
                 onClick: {
                   openLink: { url: audit.auditable_url }
                 }

--- a/lib/services/google_hangouts_chat.rb
+++ b/lib/services/google_hangouts_chat.rb
@@ -1,8 +1,8 @@
 class AhaServices::GoogleHangoutsChat < AhaService
-  caption "Send customized activity from Aha! into group chat"
+  caption "Send product notifications from Aha! to Google Hangouts Chat"
   category "Communication"
   
-  string :google_hangouts_chat_webhook_url,
+  string :webhook_url,
     description: "The URL that you copied when creating the webhook in Google Hangouts Chat"
   install_button
   
@@ -69,7 +69,7 @@ protected
   end
 
   def url
-    data.google_hangouts_chat_webhook_url
+    data.webhook_url
   end
 
   def send_message(message)

--- a/lib/services/google_hangouts_chat.rb
+++ b/lib/services/google_hangouts_chat.rb
@@ -1,0 +1,95 @@
+class AhaServices::GoogleHangoutsChat < AhaService
+  caption "Send customized activity from Aha! into group chat"
+  category "Communication"
+  
+  string :google_hangouts_chat_webhook_url,
+    description: "The webhook that you copied from the room"
+  install_button
+  
+  audit_filter
+  
+  def receive_installed
+    send_message(text: "Aha! integration installed successfully. Make sure you enable the integration!")
+  end
+  
+  def receive_audit
+    audit = payload.audit
+    return unless audit.interesting
+    
+    user = if audit.user
+        audit.user.name
+      else
+        "Aha!"
+      end
+    
+    link = if audit.auditable_url
+        "<#{audit.auditable_url}|#{audit.description}>"
+      else
+        audit.description
+      end
+
+    description = [user, audit.description].join(' ')
+      
+    kvs = audit.changes.map do |change|
+      { keyValue: { topLabel: change["field_name"], content: change["value"] } }
+    end
+    send_message(
+      cards: [
+        {
+          sections: [
+            {
+              widgets: [ { textParagraph: { text: description } } ]
+            },
+            {
+              widgets: kvs
+            },
+            {
+              widgets: [
+                {
+                  buttons: [
+                    {
+                      textButton: {
+                        text: "GO TO OBJECT",
+                        onClick: {
+                          openLink: { url: audit.auditable_url }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    )
+  end
+    
+  
+protected
+
+  def is_wide_field(field_name)
+    !["Description", "Theme", "Body"].include?(field_name)
+  end
+
+  def url
+    data.google_hangouts_chat_webhook_url
+  end
+
+  def send_message(message)
+    raise AhaService::RemoteError, "Integration has not been configured" unless url
+
+    http.headers['Content-Type'] = 'application/json'
+    response = http_post(url, message.to_json)
+    if [200, 201, 204].include?(response.status)
+      return
+    elsif response.status == 404
+      raise AhaService::RemoteError, "URL is not recognized"
+    else
+      error = Hashie::Mash.new(JSON.parse(response.body))
+      
+      raise AhaService::RemoteError, "Unhandled error: STATUS=#{response.status} BODY=#{error.message}"
+    end
+  end
+  
+end

--- a/lib/services/hip_chat.rb
+++ b/lib/services/hip_chat.rb
@@ -1,6 +1,6 @@
 class AhaServices::HipChat < AhaService
   title "HipChat"
-  caption "Send customized activity from Aha! into group chat"
+  caption "Send product notifications from Aha! to Hipchat"
   category "Communication"
   
   string :api_host, description: "API host for your on-premise HipChat installation such as 'hipchat.mycompany.com'. If you are using the cloud-hosted version of HipChat, leave this blank."

--- a/spec/services/google_hangouts_chat_spec.rb
+++ b/spec/services/google_hangouts_chat_spec.rb
@@ -1,0 +1,73 @@
+require "spec_helper"
+
+describe AhaServices::GoogleHangoutsChat do
+  let(:service_with_updated_feature) do
+    payload = {
+      "event"=>"audit",
+     "audit"=>
+      {
+        "id"=>"6543581008138760991",
+       "audit_action"=>"update",
+       "created_at"=>"2018-04-12T15:16:17.922Z",
+       "interesting"=>true,
+       "user"=>{"id"=>"6514078897796815681", "name"=>"Product Manager", "email"=>"pm@example.com", "created_at"=>"2018-01-23T03:13:02.585Z", "updated_at"=>"2018-04-10T14:36:51.715Z"},
+       "auditable_type"=>"feature",
+       "auditable_id"=>"6514078362261846610",
+       "description"=>"updated feature DEMO-28 Language options",
+       "auditable_url"=>"http://reallybigaha.lvh.me:3000/features/DEMO-28",
+       "changes"=>[{"field_name"=>"Workflow status", "value"=>"Under consideration &rarr; Ready to develop"}]
+      }
+    }
+    described_class.new( {}, payload )
+  end
+
+  let(:service_with_voted_idea) do
+    payload = {
+      "event"=>"audit",
+      "audit"=>
+      {
+        "id"=>"6543586303049439552",
+        "audit_action"=>"create",
+        "created_at"=>"2018-04-12T15:36:50.739Z",
+        "interesting"=>true,
+        "user"=>{"id"=>"6514078897796815681", "name"=>"Product Manager", "email"=>"pm@example.com", "created_at"=>"2018-01-23T03:13:02.585Z", "updated_at"=>"2018-04-12T15:36:50.763Z"},
+        "auditable_type"=>"ideas/idea_endorsement",
+        "auditable_id"=>"6543586302962967491",
+        "description"=>"voted for idea DEMO-I-15 Alert me to overtraining",
+        "auditable_url"=>"http://reallybigaha.lvh.me:3000/ideas/ideas/DEMO-I-15",
+        "changes"=>[]
+      }
+    }
+    described_class.new( {}, payload )
+  end
+
+  def get_card_sections(message)
+    message[:cards].first[:sections]
+  end
+
+  context "#receive_audit" do
+    it "sets the right number of sections when changes are present" do
+      expect(service_with_updated_feature).to receive(:send_message) do |message|
+        expect(get_card_sections(message).length).to eq(3)
+      end
+      service_with_updated_feature.receive_audit
+    end
+
+    it "sets the right number of sections when changes are present" do
+      expect(service_with_voted_idea).to receive(:send_message) do |message|
+        expect(get_card_sections(message).length).to eq(2)
+      end
+      service_with_voted_idea.receive_audit
+    end
+  end
+
+  context("#html_change_colors") do
+    subject { described_class.new }
+    it "replaces inserted and deleted <span> elements with <font> elements" do
+      edited_description = 'This is might <span class="deleted">not</span> be edited <span class="inserted">by a user</span>'
+      expect(subject.send(:html_change_colors, edited_description)).not_to include('<span')
+      expect(subject.send(:html_change_colors, edited_description)).to include('<font')
+    end
+  end
+
+end

--- a/spec/services/google_hangouts_chat_spec.rb
+++ b/spec/services/google_hangouts_chat_spec.rb
@@ -59,6 +59,15 @@ describe AhaServices::GoogleHangoutsChat do
       end
       service_with_voted_idea.receive_audit
     end
+
+    context "when audit is not interesting" do
+      subject { described_class.new({}, { "audit" => {} }) }
+
+      it "returns without sending message" do
+        expect(subject).to_not receive(:send_message)
+        subject.receive_audit
+      end
+    end
   end
 
   context("#html_change_colors") do


### PR DESCRIPTION
Adds support for an integration with google hangouts chat. We use audit records in Aha! to populate card fields in a google hangouts chat room. It works basically the same way that the slack activity feed integration does.