### PR TITLE
PF-53-56-catch-bad-xml

### DIFF
--- a/lib/services/fogbugz/fogbugz_resource.rb
+++ b/lib/services/fogbugz/fogbugz_resource.rb
@@ -48,6 +48,10 @@ class FogbugzResource < GenericResource
     else
       raise RemoteError, "Unhandled error: STATUS=#{response.status} BODY=#{response.body}"
     end
+  rescue REXML::ParseException
+    message =" Error message: Could not parse xml body"
+    message = "Error message: Account not found" if response.body.include?(">Account Not Found</p>")
+    raise RemoteError, message
   end
 
   def hashie_from_response(parsed_response_body)


### PR DESCRIPTION
Dearest Reviewer,

Fogbugz sends html for a missing account which we can not parse.

Changes
Catch xml parse errors
add an account message along side a general message

Becker