### PR TITLE
IM-419: Port html-to-jira formatter changes from aha-services-2

### DIFF
--- a/lib/services/common/color_converter.rb
+++ b/lib/services/common/color_converter.rb
@@ -1,0 +1,34 @@
+module AhaServices
+  module Services
+    module Common
+      module ColorConverter
+        AHA_COLOR_TABLE = {
+          # aha => jira
+          "#D50000" => "#d04437", # red
+          "#000000" => "#333333", # black
+          "#999999" => "#707070", # gray
+          # "" => "#cccccc", # lightgray
+          # "" => "#205081", # darkblue
+          "#0073CF" => "#59afe1", # light blue
+          # "" => "#14892c", # green
+          "#64B80B" => "#8eb021", # light green
+          "#F9931A" => "#f79232", # orange
+          # "" => "#f6c342", # yellow
+          # "" => "#654982", # purple
+          # "" => "#f691b2", # pink
+        }
+        JIRA_COLOR_TABLE = AHA_COLOR_TABLE.clone.invert
+        AHA_COLOR_TABLE.freeze
+        JIRA_COLOR_TABLE.freeze
+
+        def self.aha_color_to_jira(color)
+          AHA_COLOR_TABLE[color&.upcase] || color
+        end
+
+        def self.jira_color_to_aha(color)
+          JIRA_COLOR_TABLE[color&.downcase] || color
+        end
+      end
+    end
+  end
+end

--- a/lib/services/common/markdown_table_converter.rb
+++ b/lib/services/common/markdown_table_converter.rb
@@ -92,10 +92,10 @@ module AhaServices
             rows = node.element_children.flat_map do |child|
               if child.name == "tr"
                 [child]
-              elsif %w[tbody thead].include?(child.name)
+              elsif %w[tbody thead tfoot].include?(child.name)
                 child.element_children
               end
-            end
+            end.compact # we ignore `colgroup`, so we compact out the nils
     
             row_content = rows.each_with_index.map do |row, row_index|
               treat(row, row_index)
@@ -122,7 +122,12 @@ module AhaServices
             end
     
             table_did_end
-            content
+
+            if @options[:wrap]
+              @options[:wrap].call(content)
+            else
+              content
+            end
           end
         end
 

--- a/lib/services/jira/jira_wiki_converter.rb
+++ b/lib/services/jira/jira_wiki_converter.rb
@@ -32,6 +32,7 @@ module AhaServices
         c.register(:pre, Pre.new)
         c.register(:code, Code.new)
         c.register(:blockquote, Blockquote.new)
+        c.register(:span, Span.new)
         c.register(:font, Font.new)
 
         AhaServices::Services::Common::MarkdownTableConverter.register(c, header_cap: "||")
@@ -290,6 +291,19 @@ module AhaServices
       def convert_emoticon(node)
         emoticon = node['src'].scan(/\/emoticons\/(.+)\.(?:png|gif)/).flatten.first
         EMOTICONS[emoticon.to_sym] if emoticon
+      end
+    end
+
+    class Span < ReverseMarkdown::Converters::Base
+      def convert(node, index)
+        content = treat_children(node)
+        style = node.attributes["style"]&.value
+        if (color = style&.match(/([^-]|\A)color:([^;]{3,})/))
+          converted = AhaServices::Services::Common::ColorConverter.aha_color_to_jira(color[2])
+          "{color:#{converted}}#{content}{color}"
+        else
+          content
+        end
       end
     end
 


### PR DESCRIPTION
- Support tables with colspan
- Support text foreground and background colors