### PR TITLE
telling users when they're using the wrong connector

### DIFF
--- a/lib/services/microsoft_teams.rb
+++ b/lib/services/microsoft_teams.rb
@@ -91,6 +91,8 @@ protected
     response = http_post(url, message.to_json)
     if [200, 201, 204].include?(response.status)
       return
+    elsif response.body == 'Webhook Bad Request - Null or empty event'
+      raise AhaService::RemoteError, "Please use the Microsoft Teams Webhook connector (not the Aha! connector) for this integration."
     elsif response.status == 404
       raise AhaService::RemoteError, "URL is not recognized"
     else


### PR DESCRIPTION
When users select the Aha! connector in Microsoft teams, and use that webhook to connect to our Teams connector, they get this error. Our Teams integration connects to their webhook connector. Their Aha! connector connects to our webhook integration. This is confusing, and this tells the user what's going on rather than telling them that there's an unhandled error.