### PR TITLE
Correctly process bitbucket webhooks without author emails

### DIFF
--- a/spec/fixtures/bitbucket_commit_hook/bitbucket_commit_hook_no_email.json
+++ b/spec/fixtures/bitbucket_commit_hook/bitbucket_commit_hook_no_email.json
@@ -1,0 +1,578 @@
+{
+  "repository": {
+    "website": "",
+    "owner": {
+      "uuid": "{0eccbd2d-f827-4e6c-95e1-5b705d0c2e34}",
+      "display_name": "Alexander Bartlow",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/alexbartlow/"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/alexbartlow"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/alexbartlow/avatar/32/"
+        }
+      },
+      "username": "alexbartlow",
+      "type": "user"
+    },
+    "type": "repository",
+    "links": {
+      "html": {
+        "href": "https://bitbucket.org/alexbartlow/testrepo"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/alexbartlow/testrepo/avatar/32/"
+      }
+    },
+    "is_private": true,
+    "uuid": "{6716fcf2-0315-44ef-91e9-716ef6574c29}",
+    "full_name": "alexbartlow/testrepo",
+    "scm": "git",
+    "name": "testrepo"
+  },
+  "actor": {
+    "uuid": "{0eccbd2d-f827-4e6c-95e1-5b705d0c2e34}",
+    "display_name": "Alexander Bartlow",
+    "links": {
+      "html": {
+        "href": "https://bitbucket.org/alexbartlow/"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/alexbartlow"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/account/alexbartlow/avatar/32/"
+      }
+    },
+    "username": "alexbartlow",
+    "type": "user"
+  },
+  "push": {
+    "changes": [
+      {
+        "forced": false,
+        "created": false,
+        "closed": false,
+        "links": {
+          "diff": {
+            "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/diff/6ba351980d870d45c4e7001ef62704bcac17b53b..e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+          },
+          "commits": {
+            "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commits?include=6ba351980d870d45c4e7001ef62704bcac17b53b&exclude=e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+          },
+          "html": {
+            "href": "https://bitbucket.org/alexbartlow/testrepo/branches/compare/6ba351980d870d45c4e7001ef62704bcac17b53b..e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+          }
+        },
+        "old": {
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/refs/branches/master"
+            },
+            "commits": {
+              "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commits/master"
+            },
+            "html": {
+              "href": "https://bitbucket.org/alexbartlow/testrepo/branch/master"
+            }
+          },
+          "repository": {
+            "uuid": "{6716fcf2-0315-44ef-91e9-716ef6574c29}",
+            "links": {
+              "html": {
+                "href": "https://bitbucket.org/alexbartlow/testrepo"
+              },
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo"
+              },
+              "avatar": {
+                "href": "https://bitbucket.org/alexbartlow/testrepo/avatar/32/"
+              }
+            },
+            "full_name": "alexbartlow/testrepo",
+            "name": "testrepo",
+            "type": "repository"
+          },
+          "type": "branch",
+          "name": "master",
+          "target": {
+            "hash": "e295fd2c8df21964c685e1745cd6df955d3c0f7c",
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+              },
+              "html": {
+                "href": "https://bitbucket.org/alexbartlow/testrepo/commits/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+              }
+            },
+            "message": "Test ALEX-163\n",
+            "parents": [
+              {
+                "hash": "5810226ad46ecdb40126a3950a379b7dc1ff3bee",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/5810226ad46ecdb40126a3950a379b7dc1ff3bee"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/alexbartlow/testrepo/commits/5810226ad46ecdb40126a3950a379b7dc1ff3bee"
+                  }
+                },
+                "type": "commit"
+              }
+            ],
+            "date": "2016-08-11T18:08:54+00:00",
+            "author": {
+              "raw": "Alex Bartlow",
+              "user": {
+                "uuid": "{0eccbd2d-f827-4e6c-95e1-5b705d0c2e34}",
+                "display_name": "Alexander Bartlow",
+                "links": {
+                  "html": {
+                    "href": "https://bitbucket.org/alexbartlow/"
+                  },
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/alexbartlow"
+                  },
+                  "avatar": {
+                    "href": "https://bitbucket.org/account/alexbartlow/avatar/32/"
+                  }
+                },
+                "username": "alexbartlow",
+                "type": "user"
+              }
+            },
+            "type": "commit"
+          }
+        },
+        "new": {
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/refs/branches/master"
+            },
+            "commits": {
+              "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commits/master"
+            },
+            "html": {
+              "href": "https://bitbucket.org/alexbartlow/testrepo/branch/master"
+            }
+          },
+          "repository": {
+            "uuid": "{6716fcf2-0315-44ef-91e9-716ef6574c29}",
+            "links": {
+              "html": {
+                "href": "https://bitbucket.org/alexbartlow/testrepo"
+              },
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo"
+              },
+              "avatar": {
+                "href": "https://bitbucket.org/alexbartlow/testrepo/avatar/32/"
+              }
+            },
+            "full_name": "alexbartlow/testrepo",
+            "name": "testrepo",
+            "type": "repository"
+          },
+          "type": "branch",
+          "name": "master",
+          "target": {
+            "hash": "6ba351980d870d45c4e7001ef62704bcac17b53b",
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/6ba351980d870d45c4e7001ef62704bcac17b53b"
+              },
+              "html": {
+                "href": "https://bitbucket.org/alexbartlow/testrepo/commits/6ba351980d870d45c4e7001ef62704bcac17b53b"
+              }
+            },
+            "message": "Test ALEX-163\n",
+            "parents": [
+              {
+                "hash": "e295fd2c8df21964c685e1745cd6df955d3c0f7c",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/alexbartlow/testrepo/commits/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+                  }
+                },
+                "type": "commit"
+              }
+            ],
+            "date": "2016-08-11T18:11:06+00:00",
+            "author": {
+              "raw": "Alex Bartlow",
+              "user": {
+                "uuid": "{0eccbd2d-f827-4e6c-95e1-5b705d0c2e34}",
+                "display_name": "Alexander Bartlow",
+                "links": {
+                  "html": {
+                    "href": "https://bitbucket.org/alexbartlow/"
+                  },
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/alexbartlow"
+                  },
+                  "avatar": {
+                    "href": "https://bitbucket.org/account/alexbartlow/avatar/32/"
+                  }
+                },
+                "username": "alexbartlow",
+                "type": "user"
+              }
+            },
+            "type": "commit"
+          }
+        },
+        "truncated": false,
+        "commits": [
+          {
+            "hash": "6ba351980d870d45c4e7001ef62704bcac17b53b",
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/6ba351980d870d45c4e7001ef62704bcac17b53b"
+              },
+              "html": {
+                "href": "https://bitbucket.org/alexbartlow/testrepo/commits/6ba351980d870d45c4e7001ef62704bcac17b53b"
+              }
+            },
+            "message": "Test ALEX-163\n",
+            "parents": [
+              {
+                "hash": "e295fd2c8df21964c685e1745cd6df955d3c0f7c",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/alexbartlow/testrepo/commits/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+                  }
+                },
+                "type": "commit"
+              }
+            ],
+            "date": "2016-08-11T18:11:06+00:00",
+            "author": {
+              "raw": "Alex Bartlow",
+              "user": {
+                "uuid": "{0eccbd2d-f827-4e6c-95e1-5b705d0c2e34}",
+                "display_name": "Alexander Bartlow",
+                "links": {
+                  "html": {
+                    "href": "https://bitbucket.org/alexbartlow/"
+                  },
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/alexbartlow"
+                  },
+                  "avatar": {
+                    "href": "https://bitbucket.org/account/alexbartlow/avatar/32/"
+                  }
+                },
+                "username": "alexbartlow",
+                "type": "user"
+              }
+            },
+            "type": "commit"
+          }
+        ]
+      }
+    ]
+  },
+  "format": "json",
+  "controller": "api/v1/webhooks",
+  "action": "callback",
+  "token": "fbefbf9687b53ccbde7d24f6231581da69e851b0cba701d054ec560b1acabe86",
+  "webhook": {
+    "repository": {
+      "website": "",
+      "owner": {
+        "uuid": "{0eccbd2d-f827-4e6c-95e1-5b705d0c2e34}",
+        "display_name": "Alexander Bartlow",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/alexbartlow/"
+          },
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/alexbartlow"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/account/alexbartlow/avatar/32/"
+          }
+        },
+        "username": "alexbartlow",
+        "type": "user"
+      },
+      "type": "repository",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/alexbartlow/testrepo"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/alexbartlow/testrepo/avatar/32/"
+        }
+      },
+      "is_private": true,
+      "uuid": "{6716fcf2-0315-44ef-91e9-716ef6574c29}",
+      "full_name": "alexbartlow/testrepo",
+      "scm": "git",
+      "name": "testrepo"
+    },
+    "actor": {
+      "uuid": "{0eccbd2d-f827-4e6c-95e1-5b705d0c2e34}",
+      "display_name": "Alexander Bartlow",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/alexbartlow/"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/alexbartlow"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/alexbartlow/avatar/32/"
+        }
+      },
+      "username": "alexbartlow",
+      "type": "user"
+    },
+    "push": {
+      "changes": [
+        {
+          "forced": false,
+          "created": false,
+          "closed": false,
+          "links": {
+            "diff": {
+              "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/diff/6ba351980d870d45c4e7001ef62704bcac17b53b..e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+            },
+            "commits": {
+              "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commits?include=6ba351980d870d45c4e7001ef62704bcac17b53b&exclude=e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+            },
+            "html": {
+              "href": "https://bitbucket.org/alexbartlow/testrepo/branches/compare/6ba351980d870d45c4e7001ef62704bcac17b53b..e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+            }
+          },
+          "old": {
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/refs/branches/master"
+              },
+              "commits": {
+                "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commits/master"
+              },
+              "html": {
+                "href": "https://bitbucket.org/alexbartlow/testrepo/branch/master"
+              }
+            },
+            "repository": {
+              "uuid": "{6716fcf2-0315-44ef-91e9-716ef6574c29}",
+              "links": {
+                "html": {
+                  "href": "https://bitbucket.org/alexbartlow/testrepo"
+                },
+                "self": {
+                  "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo"
+                },
+                "avatar": {
+                  "href": "https://bitbucket.org/alexbartlow/testrepo/avatar/32/"
+                }
+              },
+              "full_name": "alexbartlow/testrepo",
+              "name": "testrepo",
+              "type": "repository"
+            },
+            "type": "branch",
+            "name": "master",
+            "target": {
+              "hash": "e295fd2c8df21964c685e1745cd6df955d3c0f7c",
+              "links": {
+                "self": {
+                  "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+                },
+                "html": {
+                  "href": "https://bitbucket.org/alexbartlow/testrepo/commits/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+                }
+              },
+              "message": "Test ALEX-163\n",
+              "parents": [
+                {
+                  "hash": "5810226ad46ecdb40126a3950a379b7dc1ff3bee",
+                  "links": {
+                    "self": {
+                      "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/5810226ad46ecdb40126a3950a379b7dc1ff3bee"
+                    },
+                    "html": {
+                      "href": "https://bitbucket.org/alexbartlow/testrepo/commits/5810226ad46ecdb40126a3950a379b7dc1ff3bee"
+                    }
+                  },
+                  "type": "commit"
+                }
+              ],
+              "date": "2016-08-11T18:08:54+00:00",
+              "author": {
+                "raw": "Alex Bartlow",
+                "user": {
+                  "uuid": "{0eccbd2d-f827-4e6c-95e1-5b705d0c2e34}",
+                  "display_name": "Alexander Bartlow",
+                  "links": {
+                    "html": {
+                      "href": "https://bitbucket.org/alexbartlow/"
+                    },
+                    "self": {
+                      "href": "https://api.bitbucket.org/2.0/users/alexbartlow"
+                    },
+                    "avatar": {
+                      "href": "https://bitbucket.org/account/alexbartlow/avatar/32/"
+                    }
+                  },
+                  "username": "alexbartlow",
+                  "type": "user"
+                }
+              },
+              "type": "commit"
+            }
+          },
+          "new": {
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/refs/branches/master"
+              },
+              "commits": {
+                "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commits/master"
+              },
+              "html": {
+                "href": "https://bitbucket.org/alexbartlow/testrepo/branch/master"
+              }
+            },
+            "repository": {
+              "uuid": "{6716fcf2-0315-44ef-91e9-716ef6574c29}",
+              "links": {
+                "html": {
+                  "href": "https://bitbucket.org/alexbartlow/testrepo"
+                },
+                "self": {
+                  "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo"
+                },
+                "avatar": {
+                  "href": "https://bitbucket.org/alexbartlow/testrepo/avatar/32/"
+                }
+              },
+              "full_name": "alexbartlow/testrepo",
+              "name": "testrepo",
+              "type": "repository"
+            },
+            "type": "branch",
+            "name": "master",
+            "target": {
+              "hash": "6ba351980d870d45c4e7001ef62704bcac17b53b",
+              "links": {
+                "self": {
+                  "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/6ba351980d870d45c4e7001ef62704bcac17b53b"
+                },
+                "html": {
+                  "href": "https://bitbucket.org/alexbartlow/testrepo/commits/6ba351980d870d45c4e7001ef62704bcac17b53b"
+                }
+              },
+              "message": "Test ALEX-163\n",
+              "parents": [
+                {
+                  "hash": "e295fd2c8df21964c685e1745cd6df955d3c0f7c",
+                  "links": {
+                    "self": {
+                      "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+                    },
+                    "html": {
+                      "href": "https://bitbucket.org/alexbartlow/testrepo/commits/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+                    }
+                  },
+                  "type": "commit"
+                }
+              ],
+              "date": "2016-08-11T18:11:06+00:00",
+              "author": {
+                "raw": "Alex Bartlow",
+                "user": {
+                  "uuid": "{0eccbd2d-f827-4e6c-95e1-5b705d0c2e34}",
+                  "display_name": "Alexander Bartlow",
+                  "links": {
+                    "html": {
+                      "href": "https://bitbucket.org/alexbartlow/"
+                    },
+                    "self": {
+                      "href": "https://api.bitbucket.org/2.0/users/alexbartlow"
+                    },
+                    "avatar": {
+                      "href": "https://bitbucket.org/account/alexbartlow/avatar/32/"
+                    }
+                  },
+                  "username": "alexbartlow",
+                  "type": "user"
+                }
+              },
+              "type": "commit"
+            }
+          },
+          "truncated": false,
+          "commits": [
+            {
+              "hash": "6ba351980d870d45c4e7001ef62704bcac17b53b",
+              "links": {
+                "self": {
+                  "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/6ba351980d870d45c4e7001ef62704bcac17b53b"
+                },
+                "html": {
+                  "href": "https://bitbucket.org/alexbartlow/testrepo/commits/6ba351980d870d45c4e7001ef62704bcac17b53b"
+                }
+              },
+              "message": "Test ALEX-163\n",
+              "parents": [
+                {
+                  "hash": "e295fd2c8df21964c685e1745cd6df955d3c0f7c",
+                  "links": {
+                    "self": {
+                      "href": "https://api.bitbucket.org/2.0/repositories/alexbartlow/testrepo/commit/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+                    },
+                    "html": {
+                      "href": "https://bitbucket.org/alexbartlow/testrepo/commits/e295fd2c8df21964c685e1745cd6df955d3c0f7c"
+                    }
+                  },
+                  "type": "commit"
+                }
+              ],
+              "date": "2016-08-11T18:11:06+00:00",
+              "author": {
+                "raw": "Alex Bartlow",
+                "user": {
+                  "uuid": "{0eccbd2d-f827-4e6c-95e1-5b705d0c2e34}",
+                  "display_name": "Alexander Bartlow",
+                  "links": {
+                    "html": {
+                      "href": "https://bitbucket.org/alexbartlow/"
+                    },
+                    "self": {
+                      "href": "https://api.bitbucket.org/2.0/users/alexbartlow"
+                    },
+                    "avatar": {
+                      "href": "https://bitbucket.org/account/alexbartlow/avatar/32/"
+                    }
+                  },
+                  "username": "alexbartlow",
+                  "type": "user"
+                }
+              },
+              "type": "commit"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/spec/services/bitbucket_webhook_spec.rb
+++ b/spec/services/bitbucket_webhook_spec.rb
@@ -30,4 +30,19 @@ describe AhaServices::BitbucketCommitHook do
     expect(comment_request.uri.path).to eq("/api/v1/features/BIG2-163/comments")
     expect(JSON.parse(comment_request.body)["comment"]["body"]).to match(/Alex Bartlow committed/)
   end
+  
+  it "processes without an author email" do
+    comment_request = nil
+    stub_request(:post, /.*/)
+      .with {|request| comment_request = request }
+      .to_return(status: 404, body: "", headers: {})
+  
+    AhaServices::BitbucketCommitHook.new(
+      {},
+      JSON.parse(fixture("bitbucket_commit_hook/bitbucket_commit_hook_no_email.json").read)
+    ).receive(:webhook)
+  
+    expect(comment_request.uri.path).to eq("/api/v1/features/ALEX-163/comments")
+    expect(JSON.parse(comment_request.body)["comment"]["body"]).to match(/Alex Bartlow committed/)
+  end
 end


### PR DESCRIPTION
There is an issue where a Bitbucket user can not have an email configured so the author field comes through with no email. This causes `Mail::Address` to raise an exception and fails the comment posting process. Since the email address is used as an identifier at best, there's no reason we can't just use the raw string if we can't break it out into a display name and email.

