### PR TITLE
PF-366-1: Jira Connect GDPR changes

### DIFF
--- a/lib/aha-services.rb
+++ b/lib/aha-services.rb
@@ -17,6 +17,7 @@ require 'ipaddr'
 require 'socket'
 require 'hashie'
 require 'aha-api'
+require 'jwt'
 
 require 'aha-services/version'
 require 'aha-services/networking'

--- a/lib/services/jira/jira_resource.rb
+++ b/lib/services/jira/jira_resource.rb
@@ -48,10 +48,10 @@ class JiraResource < GenericResource
 
   def faraday_builder(builder)
     if jira_connect_resource?
-      builder.request :add_jira_user, @service.data.user_id
       if @service.data.shared_secret
-        builder.request :add_jira_jwt,  @service.data.client_key, 
-          @service.data.shared_secret, @service.data.server_url
+        builder.request :add_jira_jwt, @service.data.shared_secret,
+          @service.data.user_id, @service.data.atlassian_account_id,
+          @service.data.server_url
       else
         builder.request :oauth, consumer_key: @service.data.consumer_key,
           consumer_secret: @service.data.consumer_secret, signature_method: "RSA-SHA1"
@@ -68,54 +68,48 @@ protected
   end
 
   def jira_connect_resource?
-    @service.data.user_id
+    @service.data.atlassian_account_id || @service.data.user_id
   end
 
-end
-
-class AddJiraUser < Faraday::Middleware
-
-  def initialize(app, user_id)
-    @app = app
-    @user_id = user_id
-  end
-
-  def call(env)
-    uri = env[:url]
-    uri.query = [uri.query, "user_id=#{URI.escape(@user_id)}"].compact.join('&')
-
-    @app.call(env)
-  end
 end
 
 class AddJiraJwt < Faraday::Middleware
-  
-  def initialize(app, client_key, shared_secret, context_url)
+  def initialize(app, shared_secret, user_id, atlassian_account_id, context_url)
     @app = app
-    @client_key, @shared_secret, @context_url = client_key, shared_secret, context_url
+    @shared_secret = shared_secret
+    @user_id = user_id
+    @atlassian_account_id = atlassian_account_id
+    @context_url = context_url
   end
 
   def call(env)
     uri = env[:url]
-    
+
     canonical_url = canonical_url(env[:method].to_s.upcase, uri)
     qsh = Digest::SHA256.new.hexdigest(canonical_url)
-    
-    jwt = JWT.encode({"iss" => "io.aha.connect", "iat" => Time.now.utc.to_i, 
-      "exp" => Time.now.utc.to_i + 300, "qsh" => qsh}, @shared_secret, "HS256")
-    
+
+    claims = {
+      'iss' => 'io.aha.connect',
+      'iat' => Time.now.utc.to_i,
+      'exp' => Time.now.utc.to_i + 300,
+      'qsh' => qsh
+    }
+    claims.merge!(sub_claim) if sub_claim
+
+    jwt = JWT.encode(claims, @shared_secret, 'HS256')
+
     uri.query = [uri.query, "jwt=#{jwt}"].compact.join('&')
 
     @app.call(env)
   end
-  
+
   def path_without_context(path)
     context_path = URI.parse(@context_url).path
     new_path = path.sub(context_path, "")
     new_path = "/" if new_path.blank?
     new_path
   end
-  
+
   def canonical_url(method, uri)
     [method, path_without_context(uri.path), normalized_params(Rack::Utils.parse_query(uri.query))].join('&')
   end
@@ -123,11 +117,18 @@ class AddJiraJwt < Faraday::Middleware
   def normalized_params(params)
     params.map{|p| p.map{|v| escape(v) } }.sort.map{|p| p.join('=') }.join('&')
   end
-  
+
   def escape(value)
     URI.escape(value.to_s, /[^a-z0-9\-\.\_\~]/i)
   end
+
+  def sub_claim
+    @sub_claim ||= if @atlassian_account_id.present?
+      { 'sub' => "urn:atlassian:connect:useraccountid:#{@atlassian_account_id}" }
+    elsif @user_id.present?
+      { 'sub' => "urn:atlassian:connect:userkey:#{@user_id}" }
+    end
+  end
 end
 
-Faraday::Request.register_middleware :add_jira_user => lambda { AddJiraUser }
 Faraday::Request.register_middleware :add_jira_jwt => lambda { AddJiraJwt }

--- a/spec/services/jira/jira_resource_spec.rb
+++ b/spec/services/jira/jira_resource_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+RSpec.describe JiraResource do
+  let(:resource) { described_class.new(service) }
+  let(:service) { AhaServices::Jira.new(service_options) }
+
+  context 'jwt handling' do
+    let(:api_url) { 'https://test.host/api/v2' }
+    let(:service_options) do
+      {
+        user_id: user_id,
+        atlassian_account_id: atlassian_account_id,
+        shared_secret: shared_secret,
+        server_url: 'https://test.host'
+      }
+    end
+    let(:user_id) {}
+    let(:atlassian_account_id) {}
+    let(:shared_secret) { 'shhhhh' }
+    let(:request_regex) { /#{api_url}(\?jwt=.*)?/ }
+
+    before { stub_request(:get, request_regex).to_return(status: 200) }
+
+    def claims
+      jwt = nil
+      expect(
+        a_request(:get, request_regex)
+          .with { |req| jwt = req.uri.query_values['jwt'] }
+      ).to have_been_made
+      JWT.decode(jwt, shared_secret, true).first
+    end
+
+    # This is where the action happens. It's not in a subject block because we
+    # don't care about the result
+    before { resource.http_get(api_url) }
+
+    shared_examples_for 'a Jira request with JWT' do
+      it 'has no user_id param' do
+        expect(a_request(:get, api_url)
+          .with(query: hash_including(user_id: user_id))).to_not have_been_made
+      end
+
+      it 'has a jwt param' do
+        expect(a_request(:get, api_url)
+          .with(query: hash_including(jwt: anything))).to have_been_made
+      end
+
+      it 'sets the iss claim to aha' do
+        expect(claims['iss']).to eq('io.aha.connect')
+      end
+
+      it 'sets the iat claim' do
+        expect(claims['iat'].to_s).to match(/\d+/)
+      end
+
+      it 'sets the exp claim to 5 minutes from now' do
+        expect(claims['exp']).to be >= Time.now.utc.to_i
+      end
+
+      it 'sets the qsh claim' do
+        expect(claims['qsh']).to be_present
+      end
+    end
+
+    context 'when service config contains a user_id' do
+      let(:user_id) { 'user-id-abc123' }
+
+      it_behaves_like 'a Jira request with JWT'
+
+      it 'sets the sub claim with the user key' do
+        expect(claims['sub']).to eq("urn:atlassian:connect:userkey:#{user_id}")
+      end
+    end
+
+    context 'when service config has an atlassian_account_id' do
+      let(:atlassian_account_id) { 'account-id-abc123' }
+
+      it_behaves_like 'a Jira request with JWT'
+
+      it 'sets the sub claim with the account ID' do
+        expect(claims['sub'])
+          .to eq("urn:atlassian:connect:useraccountid:#{atlassian_account_id}")
+      end
+    end
+
+    context 'when service config has a blank user_id' do
+      let(:user_id) { '' }
+
+      it_behaves_like 'a Jira request with JWT'
+
+      it 'does not set the sub claim' do
+        expect(claims).to_not have_key('sub')
+      end
+    end
+
+    context 'when service config has no user_id or atlassian_account_id' do
+      it 'has no user_id param' do
+        expect(
+          a_request(:get, api_url)
+            .with(query: hash_including(user_id: anything))
+        ).to_not have_been_made
+      end
+
+      it 'has no jwt param' do
+        expect(
+          a_request(:get, api_url)
+            .with(query: hash_including(jwt: anything))
+        ).to_not have_been_made
+      end
+
+      it 'has no auth header' do
+        expect(
+          a_request(:get, api_url)
+            .with { |req| req.headers['HTTP_AUTHORIZATION'] =~ /^OAuth / }
+        ).to_not have_been_made
+      end
+    end
+  end
+end


### PR DESCRIPTION
As part of Atlassian's GDPR compliance effort, there are several changes that affect the way that Jira Connect integrations authenticate with the remote server ([Connect app migration guide](https://developer.atlassian.com/cloud/jira/platform/connect-app-migration-guide/#migrating-existing-app)). Specifically:
- the `user_id` and `user_key` params are being removed
- the `user` section of the JWT `context` claim is being removed
- the user must be identified in the `sub` claim of the JWT payload, using a namespaced urn that identifies the value as either an Atlassian account ID (preferred) or user key (deprecated, to be removed soon)