### PR TITLE
PF-420: Use the Jira user account ID for reporter/assignee

### DIFF
--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -558,7 +558,11 @@ protected
 
   def assignee_fields(resource, issue_type)
     if (issue_type.has_field_assignee.nil? || issue_type.has_field_assignee) && resource.assigned_to_user && !resource.assigned_to_user.default_assignee && (user = user_resource.picker(resource.assigned_to_user.email, resource.assigned_to_user.name))
-      { assignee: { name: user.name } }
+      if user.accountId
+        { assignee: { accountId: user.accountId } }
+      else
+        { assignee: { name: user.name } }
+      end
     else
       Hash.new
     end
@@ -566,7 +570,11 @@ protected
 
   def reporter_fields(resource, issue_type)
     if (issue_type.has_field_reporter.nil? || issue_type.has_field_reporter) && resource.created_by_user && (user = user_resource.picker(resource.created_by_user.email, resource.created_by_user.name))
-      { reporter: { name: user.name } }
+      if user.accountId
+        { reporter: { accountId: user.accountId } }
+      else
+        { reporter: { name: user.name } }
+      end
     else
       Hash.new
     end


### PR DESCRIPTION
It appears that Jira's `POST /api/2/issue` endpoint recently (sometime over the weekend) changed to only accept the user `accountId` to identify the issue reporter and assignee, whereas previously, it would accept either the user `name` or the user `accountId`. We still need to support user `name` (without the `accountId`) for on-prem instances.

This is part of the [Atlassian GDPR changes](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/#issue).