### PR TITLE
APPS-226: Ignore unicode checkboxes in checklists

### DIFF
--- a/lib/services/jira/jira_wiki_converter.rb
+++ b/lib/services/jira/jira_wiki_converter.rb
@@ -296,6 +296,7 @@ module AhaServices
 
     class Span < ReverseMarkdown::Converters::Base
       def convert(node, index)
+        return "" if node["class"].to_s.include?("checklist-item__indicator")
         content = treat_children(node)
         style = node.attributes["style"]&.value
         if (color = style&.match(/([^-]|\A)color:([^;]{3,})/))

--- a/spec/services/jira/jira_wiki_converter_spec.rb
+++ b/spec/services/jira/jira_wiki_converter_spec.rb
@@ -420,14 +420,14 @@ RSpec.describe AhaServices::JiraWikiConverter do
     let(:input) do
       <<~HTML
         <ul class="checklist">
-          <li class="checklist--unchecked">check 1</li>
+          <li class="checklist-item--unchecked"><span class="checklist-item__indicator">☐</span>check 1</li>
           <li class="checkbox">
-            <span>check 2</span>
+            <span class="checklist-item__indicator">☑</span><span>check 2</span>
             <ul class="checklist">
-              <li class="checkbox checklist--checked">check 2.1</li>
+              <li class="checkbox checklist-item--checked">check 2.1</li>
             </ul>
           </li>
-          <li class="checklist--checked">check 3</li>
+          <li class="checklist-item--checked"><span class="checklist-item__indicator">☑</span>check 3</li>
         </ul>
       HTML
     end


### PR DESCRIPTION
To get checklists to appear correctly in HTML and emails, we need to
add an element with a unicode checkbox. When sending the HTML to Jira,
we replace checklists with images. In those cases, we want to ignore
the other checkboxes.