### PR TITLE
PF-642: Use GitHub markdown converter for GitLab

### DIFF
--- a/lib/services/gitlab_issues.rb
+++ b/lib/services/gitlab_issues.rb
@@ -285,7 +285,7 @@ class AhaServices::GitlabIssues < AhaService
   def issue_body(resource)
     issue_body_parts = []
     if resource.description.body.present?
-      body = html_to_markdown(resource.description.body, true)
+      body = html_to_markdown(resource.description.body)
       body = bugfix_escaping_in_method_name(body)
       issue_body_parts << body
     end
@@ -370,7 +370,7 @@ class AhaServices::GitlabIssues < AhaService
     resource.requirements.map do |requirement|
       status = (requirement.workflow_status.try(:complete) || false) ? "x" : " "
       head = "- [#{status}] #{requirement.name}\n"
-      body = html_to_markdown(requirement.description.body, true)
+      body = html_to_markdown(requirement.description.body)
       body += attachments_in_body(requirement.description.attachments) if requirement.description.attachments.present?
       head + indent(body, "    ")
     end.join("\n").gsub(/\n+/m, "\n")
@@ -378,5 +378,9 @@ class AhaServices::GitlabIssues < AhaService
 
   def indent text, prefix
     text.lines.map{|line| prefix + line.chomp }.join("\n")
+  end
+
+  def html_to_markdown(html)
+    GithubMarkdownConverter.new.convert_html_from_aha(html) 
   end
 end


### PR DESCRIPTION
Has better table support.

Before

<img width="422" alt="Screenshot 2019-11-08 14 50 15" src="https://user-images.githubusercontent.com/1896112/68506272-427a7580-0237-11ea-9508-2d42d5640f73.png">


After

<img width="211" alt="Screenshot 2019-11-08 14 50 21" src="https://user-images.githubusercontent.com/1896112/68506278-473f2980-0237-11ea-9bcc-709b209bb46e.png">

GitLab flavored markdown is advertised as a superset of GitHub flavored markdown, so there shouldn't be a problem with any of the other syntax conversion. https://gitlab.com/gitlab-org/gitlab-foss/issues/52391