### PR TITLE
Use name not key for jira fields

### DIFF
--- a/lib/services/jira/jira_mapped_fields.rb
+++ b/lib/services/jira/jira_mapped_fields.rb
@@ -86,7 +86,9 @@ module JiraMappedFields
     key = nil
     email_add = aha_type == "string" ? field.value : field.email_value
     Array(email_add).each do |email|
-      key = user_resource.picker(email.strip).try(:[], :key)
+      user = user_resource.picker(email.strip)
+      key = user.try(:[], :name)
+      key ||= user.try(:[], :key)
     end
     key
   end


### PR DESCRIPTION
Integrations 2.0 has been changed to use the name field instead of the key field, but for v1 only the assignee field was updated also update custom fields.