### PR TITLE
Fixes IM-1225 - Handle 'Connector configuration not found' error.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 gem "aha-api", :git => "https://github.com/aha-app/aha-api"
 
 gem "html2confluence", :git => "https://github.com/aha-app/html2confluence.git"
-gem "reverse_markdown", :git => "https://github.com/aha-app/reverse_markdown.git", branch: "instances"
+gem "reverse_markdown", :git => "https://github.com/aha-app/reverse_markdown.git"
 gem "redcarpet"
 gem "plain-david", git: "https://github.com/k1w1/plain-david.git" # HTML to plain text conversion.
 gem "sinatra"

--- a/lib/services/microsoft_teams.rb
+++ b/lib/services/microsoft_teams.rb
@@ -1,20 +1,20 @@
 class AhaServices::MicrosoftTeams < AhaService
   caption "Send workspace notifications from Aha! to Microsoft Teams"
   category "Communication"
-  
+
   string :webhook_url,
     description: "The URL that you copied when creating the webhook in Microsoft Teams"
   install_button
-  
+
   audit_filter
-  
+
   def receive_installed
     send_message(text: "Aha! integration installed successfully. Make sure you enable the integration!")
   end
-  
+
   def receive_audit
     return unless payload.audit.interesting
-    
+
     # array of elements with {"name": "asdf", "value": "the change"}
     facts = payload.audit.changes.each do |obj|
       obj["name"] = obj.delete("field_name")
@@ -63,8 +63,8 @@ class AhaServices::MicrosoftTeams < AhaService
     }
     send_message(message)
   end
-  
-protected
+
+  protected
 
   def title
     user = payload.audit.user&.name || "Aha!"
@@ -85,13 +85,14 @@ protected
       return
     elsif response.body == 'Webhook Bad Request - Null or empty event'
       raise AhaService::RemoteError, "Please use the Microsoft Teams Webhook connector (not the Aha! connector) for this integration."
+    elsif response.body == "Connector configuration not found"
+      raise AhaService::RemoteError, "The connector configuration was not found"
     elsif response.status == 404
       raise AhaService::RemoteError, "URL is not recognized"
     else
       error = Hashie::Mash.new(JSON.parse(response.body))
-      
+
       raise AhaService::RemoteError, "Unhandled error: STATUS=#{response.status} BODY=#{error.message}"
     end
   end
-  
 end


### PR DESCRIPTION
We were throwing an error when the response only contained `Connector configuration not found` because we were trying to parse this as if it was JSON.