### PR TITLE
PF-1011 We need a newer hashie gem to support omniauth-github.

### DIFF
--- a/aha-services.gemspec
+++ b/aha-services.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_development_dependency "rspec"
-  s.add_development_dependency "webmock"
+  s.add_development_dependency "webmock", "~> 2.3.2"
   s.add_development_dependency "rspec_junit_formatter"
-  s.add_dependency "hashie", "~> 2.1.1"
+  s.add_dependency "hashie", "~> 3.6"
   s.add_dependency "faraday", "~> 0.9.0"
   s.add_dependency "faraday_middleware", "~> 0.9.0"
   s.add_dependency "faraday-cookie_jar"

--- a/lib/aha-services.rb
+++ b/lib/aha-services.rb
@@ -19,6 +19,10 @@ require 'hashie'
 require 'aha-api'
 require 'jwt'
 
+# This is brutal, but we need it to the backwards compatible behavior of 
+# not logging warnings without rewriting all our code to use a new subclass.
+Hashie::Mash.instance_variable_set(:@disable_warnings, true)
+
 require 'aha-services/version'
 require 'aha-services/networking'
 require 'aha-services/schema'


### PR DESCRIPTION
Disable warnings about shadowing keys. 

It turns out that Hashie::Mash has always shadowed keys, the warning is new.