### PR TITLE
DEVOPS-479: handle lines with trailing whitespace in markdown to html conversion

### DIFF
--- a/lib/aha-services/helpers.rb
+++ b/lib/aha-services/helpers.rb
@@ -82,8 +82,12 @@ module Helpers
   end
 
   def markdown_to_html(markdown)
+    # hard_wrap will respect newlines in the markdown and convert them to link break elements
     converter = Redcarpet::Markdown.new(AhaTableRender.new(hard_wrap: true), autolink: true, tables: true)
-    converter.render(markdown).tap do |html|
+
+    # If there is any whitespace before the end of a line the hard_wrap option
+    # will convert that into multiple line breaks which is not desirable
+    converter.render(markdown.gsub(/ *$/, "")).tap do |html|
       # The :hard_wrap option leaves the old newlines in place after adding <br/>
       # elements. This results in \n\n when converted back to plain text which is
       # not good. So clean them up.

--- a/spec/lib/aha-services/helpers_spec.rb
+++ b/spec/lib/aha-services/helpers_spec.rb
@@ -18,6 +18,12 @@ describe Helpers do
       it { is_expected.to eq("<p>line 1</p><p>line 2</p><p>line 3</p>") }
     end
 
+    context "whitespace before newlines don't create multiple line breaks" do
+      let(:md) { "line 1  \nline 2" }
+
+      it { is_expected.to eq("<p>line 1<br>line 2</p>") }
+    end
+
     context "single newlines are converted to <br>" do
       let(:md) { "this text has\na newline\nand another" }
 


### PR DESCRIPTION
This handles a string line `Line 1  \nLine 2` not rendering to HTML as `<p>Line 1<br><br>Line 2</p>` with duplicate line break elements.