### PR TITLE
A-11529: Pivotal V1 integration does not support initiatives

### DIFF
--- a/lib/services/pivotal_tracker.rb
+++ b/lib/services/pivotal_tracker.rb
@@ -19,8 +19,7 @@ class AhaServices::PivotalTracker < AhaService
   select :mapping, collection: [
         ["Feature -> Story, Requirement -> Story", "story-story"],
         ["Feature -> Epic, Requirement -> Story", "epic-story"],
-        ["Feature -> Story, Requirement -> Task", "story-task"],
-        ["Initiative -> Epic, Feature -> Story, Requirement -> Task", "epic-story-task"]
+        ["Feature -> Story, Requirement -> Task", "story-task"]
       ],
     description: "Choose how features and requirements in Aha! will map to epics, stories and tasks in Pivotal Tracker."
   internal :feature_status_mapping

--- a/lib/services/pivotal_tracker/pivotal_tracker_feature_and_requirement_mapping_resource.rb
+++ b/lib/services/pivotal_tracker/pivotal_tracker_feature_and_requirement_mapping_resource.rb
@@ -43,6 +43,8 @@ private
     end
   end
   
+  # Looks like this code was never fully hooked up. We removed the options to
+  # use "epic-story-task".
   def initiative_mapping_resource
     @initiative_mapping_resource ||= (mapping == "epic-story-task") ?
       PivotalTrackerEpicResource.new(@service, project_id) :


### PR DESCRIPTION
We do not support initiatives in the pivotal integration, but we have included it as an option in the settings. Removing it as the only customer to ever use it so far is in a trial. We should just put the effort towards making a v2 integration.

* [Support ticket](https://ahasupport.zendesk.com/agent/tickets/593950)