### PR TITLE
DEVELOP-1246: Fix basic auth on v1 Jira integrations

### DIFF
--- a/lib/services/jira/jira_resource.rb
+++ b/lib/services/jira/jira_resource.rb
@@ -1,11 +1,4 @@
 class JiraResource < GenericResource
-  def faraday_builder(builder)
-    # No auth in JiraConnect - we are doing it with middleware.
-    unless jira_connect_resource?
-      builder.request(:basic_auth, @service.data.username, @service.data.password)
-    end
-  end
-
   def error_message_for_field key, value
     jira_field_name = @service.meta_data.fields[key]["name"] rescue key
     field_info = @service.data.field_mapping.grep(Hash).detect{|m| m["jira_field"] == key }
@@ -51,7 +44,7 @@ class JiraResource < GenericResource
           consumer_secret: @service.data.consumer_secret, signature_method: "RSA-SHA1"
       end
     else
-      super
+      builder.request(:basic_auth, @service.data.username, @service.data.password)
     end
   end
 

--- a/spec/services/jira/jira_resource_spec.rb
+++ b/spec/services/jira/jira_resource_spec.rb
@@ -8,6 +8,28 @@ RSpec.describe JiraResource do
     allow(IPSocket).to receive(:getaddress).with("test.host").and_return("123.123.123.123")
   end
 
+  context 'basic auth' do
+    let(:api_url) { 'https://test.host/api/v2' }
+    let(:service_options) do
+      {
+        username: "testuser@jira.com",
+        password: "secret",
+        server_url: 'https://test.host'
+      }
+    end
+    let(:request_regex) { /#{api_url}/ }
+
+    before { stub_request(:get, request_regex).to_return(status: 200) }
+
+    it 'has an auth header' do
+      resource.http_get(api_url)
+      expect(
+        a_request(:get, api_url)
+          .with { |req| req.headers['Authorization'] =~ /^Basic / }
+      ).to have_been_made
+    end
+  end
+
   context 'jwt handling' do
     let(:api_url) { 'https://test.host/api/v2' }
     let(:service_options) do


### PR DESCRIPTION
During the Ruby 3 upgrade, we changed how the auth headers were added in several integrations. The change made to the Jira moved the code into a method that was being overridden by a method further down in the class. We need to move the auth code into that method for it to run.