### PR TITLE
DEVOPS-1683: Fix services fixtures

### DIFF
--- a/spec/fixtures/update_feature_event.json
+++ b/spec/fixtures/update_feature_event.json
@@ -1,7 +1,7 @@
 {
-  "event": "create_feature",
+  "event": "update_feature",
   "feature": {
-    "name": "Feature with attachments (new)",
+    "name": "Feature with attachments",
     "reference_num": "PROD-2",
     "position": 2,
     "score": 0,
@@ -185,13 +185,13 @@
           {
             "id": "18669867",
             "name": "id",
-            "value": "dummy_trello_checklist_item_id",            
+            "value": "dummy_trello_checklist_item_id",
             "service_name": "trello"
           },
           {
             "id": "18669868",
             "name": "checklist_id",
-            "value": "dummy_trello_checklist_id",            
+            "value": "dummy_trello_checklist_id",
             "service_name": "trello"
           },
           {


### PR DESCRIPTION
An eagle-eyed customer noticed that the `event` on an eight year old fixture in `aha-services` is incorrect. It's also incorrect in `aha-services-2`.


Changes: Fix fixture

* [Support ticket](https://ahasupport.zendesk.com/agent/tickets/814022)