### PR TITLE
DEVOPS-1932: fix gitlab integration issue links not using the newer subgroup format

### DIFF
--- a/lib/services/gitlab_issues.rb
+++ b/lib/services/gitlab_issues.rb
@@ -355,12 +355,12 @@ class AhaServices::GitlabIssues < AhaService
 
   def integrate_release_with_gitlab_milestone(release, milestone)
     api.create_integration_fields("releases", release.reference_num, data.integration_id,
-      {milestone_id: milestone['id'], number: milestone['iid'], url: "#{get_project_url}/milestones/#{milestone['iid']}"})
+      {milestone_id: milestone['id'], number: milestone['iid'], url: milestone['web_url']})
   end
 
   def integrate_resource_with_gitlab_issue(resource, issue)
     api.create_integration_fields(reference_num_to_resource_type(resource.reference_num), resource.reference_num, data.integration_id,
-      {id: issue['id'], number: issue['iid'], url: "#{get_project_url}/issues/#{issue['iid']}"})
+      {id: issue['id'], number: issue['iid'], url: issue['web_url']})
   end
 
   def requirements_to_checklist?
@@ -382,6 +382,6 @@ class AhaServices::GitlabIssues < AhaService
   end
 
   def html_to_markdown(html)
-    GithubMarkdownConverter.new.convert_html_from_aha(html) 
+    GithubMarkdownConverter.new.convert_html_from_aha(html)
   end
 end


### PR DESCRIPTION
Newer GitLab versions use a new URL format with a spot in the URL for project subgroups. Our integration uses the older format, however, which results in broken integration links. This patch updates the integration to use the web URL as reported by the server which will use whichever URL format it uses (and also will account for populated subgroups, if one exists). This should support past, present, and future GitLab servers as both the current v4 API includes this field as well as the much older v3 API.

Ref: https://gitlab.com/gitlab-org/gitlab/-/issues/214217