### PR TITLE
Add  to possible extension fields

### DIFF
--- a/docs/zendesk.md
+++ b/docs/zendesk.md
@@ -10,7 +10,7 @@ The app will use one user account within Aha! for all Zendesk agents - so there 
 Select an ideas portal for the integration:
 
 * The portal should include all the workspaces you want to be available for capturing ideas in Zendesk
-* This portal is used for subscribing customers to ideas and creating ideas portal users, if you have enabled these options in this Zendesk app.
+* This portal is used for linking customers or agents to ideas and creating ideas portal users
 
 The Zendesk app is configured within Zendesk:
 

--- a/docs/zendesk.md
+++ b/docs/zendesk.md
@@ -7,6 +7,11 @@ To use the Zendesk app you must:
 
 The app will use one user account within Aha! for all Zendesk agents - so there is no need to have an Aha! user for each agent.
 
+Select an ideas portal for the integration:
+
+* The portal should include all the workspaces you want to be available for capturing ideas in Zendesk
+* This portal is used for subscribing customers to ideas and creating ideas portal users, if you have enabled these options in this Zendesk app.
+
 The Zendesk app is configured within Zendesk:
 
 1. In your Zendesk agent interface, navigate to the _Apps Marketplace_.

--- a/lib/aha-services/schema.rb
+++ b/lib/aha-services/schema.rb
@@ -51,6 +51,10 @@ module Schema
     def webhooks_slack_button(options = {})
       add_to_schema :webhooks_slack_button, "webhooks_slack_button", options
     end
+
+    def ideas_portals(options = {})
+      add_to_schema :ideas_portals, "ideas_portals", options
+    end
     
     def internal(name, options = {})
       add_to_schema :internal, name, options

--- a/lib/aha-services/schema.rb
+++ b/lib/aha-services/schema.rb
@@ -51,10 +51,6 @@ module Schema
     def webhooks_slack_button(options = {})
       add_to_schema :webhooks_slack_button, "webhooks_slack_button", options
     end
-
-    def ideas_portals(options = {})
-      add_to_schema :ideas_portals, "ideas_portals", options
-    end
     
     def internal(name, options = {})
       add_to_schema :internal, name, options

--- a/lib/services/zendesk.rb
+++ b/lib/services/zendesk.rb
@@ -1,4 +1,6 @@
 class AhaServices::Zendesk < AhaService
   caption "Receive ideas from a Zendesk helpdesk"
   category "Customer relationship management"
+
+  ideas_portals
 end

--- a/lib/services/zendesk.rb
+++ b/lib/services/zendesk.rb
@@ -2,5 +2,5 @@ class AhaServices::Zendesk < AhaService
   caption "Receive ideas from a Zendesk helpdesk"
   category "Customer relationship management"
 
-  ideas_portals
+  internal :idea_portal_id
 end


### PR DESCRIPTION
DO NOT MERGE Depends on https://github.com/aha-app/aha-app/pull/27013

Adds a `ideas_portals` field that can be used to render a list of ideas portals to associate to the extension.

* [Aha! feature](https://big.aha.io/features/AI-1015)