### PR TITLE
Allow gitlab projects to be found by the suffix

### DIFF
--- a/lib/services/gitlab_issues.rb
+++ b/lib/services/gitlab_issues.rb
@@ -324,6 +324,8 @@ class AhaServices::GitlabIssues < AhaService
   def get_project
     meta_data.repos.find do |repo|
       repo.slice("path_with_namespace", "full_name").values.any? { |value| value.to_s == data.project }
+    end || meta_data.repos.find do |repo|
+      repo["path_with_namespace"].ends_with?(data.project)
     end
   end
 


### PR DESCRIPTION
Some gitlab projects have prefixes which cause the `get_project` method to not return the correct project.

In these cases, we can additionally check the `path_with_namespace` to find a project ending with the data.project.