### PR TITLE
A-17023 Update the slack names

### DIFF
--- a/lib/services/slack.rb
+++ b/lib/services/slack.rb
@@ -1,5 +1,5 @@
 class AhaServices::Slack < AhaService
-  title "Slack [from Aha!]"
+  title "Aha! (to Slack)"
   caption "Send workspace notifications from Aha! to Slack"
   category "Communication"
 

--- a/lib/services/slack_commands.rb
+++ b/lib/services/slack_commands.rb
@@ -1,5 +1,5 @@
 class AhaServices::SlackCommands < AhaService
-  title "Slack [to Aha!]"
+  title "Aha! (from Slack)"
   caption "Send new ideas and work updates to Aha! from Slack"
   category "Communication"
 


### PR DESCRIPTION
## Description 

[Aha Feature](https://big.aha.io/features/A-17023)

As part of the update to our Slack application, we need to rename our existing application so they are not "Slack [From Aha!]" as Slack is very strict about it. Instead we have to use something like "Aha! (To Slack)"