### PR TITLE
A-17418: Fix sending integer values to MS teams integration

### DIFF
--- a/lib/services/microsoft_teams.rb
+++ b/lib/services/microsoft_teams.rb
@@ -216,6 +216,6 @@ class AhaServices::MicrosoftTeams < AhaService
   #     - The * means "zero or more" of these characters,
   #     - Finally, it checks for a closing >.
   def html?(string)
-    string =~ /<[^>]*>/ ? true : false
+    string.to_s =~ /<[^>]*>/ ? true : false
   end
 end

--- a/spec/lib/services/microsoft_teams_spec.rb
+++ b/spec/lib/services/microsoft_teams_spec.rb
@@ -190,5 +190,19 @@ describe AhaServices::MicrosoftTeams do
       expect(fact["title"]).to eq("Description")
       expect(fact["value"]).to eq("Some description\n")
     end
+
+    it "can handle integers as the audited change value" do
+      audited_changes = [
+        { "title" => "Estimate", "value" => 5 },
+      ]
+      payload = double(audit: double(created_at: Time.now, auditable_url: "http://example.com", user: nil, description: "did something", changes: audited_changes))
+      allow(subject).to receive(:payload).and_return(payload)
+      allow(subject).to receive(:title).and_return("Aha! did something")
+      allow(subject).to receive(:audit_time).and_return("2024-08-23 3:45 PM")
+
+      fact = subject.send(:workflow_message)[:attachments][0][:content][:body].last[:facts][0]
+      expect(fact["title"]).to eq("Estimate")
+      expect(fact["value"]).to eq(5)
+    end
   end
 end


### PR DESCRIPTION
It wasn't working when the change value was an integer. Cast values to strings before checking if it's HTML.

[Sentry](https://aha-labs-inc.sentry.io/issues/5906962981/?project=139823&query=is%3Aunresolved%20user.id%3A6950149701032285048&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=0)
[Ticket](https://ahasupport.zendesk.com/agent/tickets/1012895)